### PR TITLE
Feat(lp-token): add LP token issuance for liquidity contributions (Minting, Burning, and Viewing Token Balances)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { PolicysModule } from "./policys/policys.module"
 import { ClaimModule } from "./claim/claim.module"
 import { GovernanceModule } from "./governance/governance.module"
 import { MailModule } from "./mail/mail.module"
+import { LpTokenModule } from './lp-token/lp-token.module';
 
 @Module({
   imports: [
@@ -42,6 +43,7 @@ import { MailModule } from "./mail/mail.module"
     ClaimModule,
     GovernanceModule,
     MailModule,
+    LpTokenModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/lp-token/dtos/burn-lp-token.dto.ts
+++ b/src/lp-token/dtos/burn-lp-token.dto.ts
@@ -1,0 +1,9 @@
+import { IsNumber, IsString } from 'class-validator';
+
+export class BurnLpTokenDto {
+  @IsString()
+  tokenId: string;
+
+  @IsNumber()
+  amount: number;
+}

--- a/src/lp-token/dtos/mint-lp-token.dto.ts
+++ b/src/lp-token/dtos/mint-lp-token.dto.ts
@@ -1,0 +1,9 @@
+import { IsNumber } from 'class-validator';
+
+export class MintLpTokenDto {
+  @IsNumber()
+  amount: number;
+
+  @IsNumber()
+  poolId: number;
+}

--- a/src/lp-token/lp-token.controller.ts
+++ b/src/lp-token/lp-token.controller.ts
@@ -1,0 +1,33 @@
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+  Get,
+  Request,
+} from '@nestjs/common';
+import { LpTokenService } from './lp-token.service';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { MintLpTokenDto } from './dtos/mint-lp-token.dto';
+import { BurnLpTokenDto } from './dtos/burn-lp-token.dto';
+
+@Controller('lp-token')
+@UseGuards(JwtAuthGuard)
+export class LpTokenController {
+  constructor(private readonly lpTokenService: LpTokenService) {}
+
+  @Post('mint')
+  async mint(@Request() req, @Body() dto: MintLpTokenDto) {
+    return this.lpTokenService.mint(req.user.id, dto);
+  }
+
+  @Post('burn')
+  async burn(@Request() req, @Body() dto: BurnLpTokenDto) {
+    return this.lpTokenService.burn(req.user.id, dto);
+  }
+
+  @Get('me')
+  async getMyTokens(@Request() req) {
+    return this.lpTokenService.findByUser(req.user.id);
+  }
+}

--- a/src/lp-token/lp-token.entity.ts
+++ b/src/lp-token/lp-token.entity.ts
@@ -1,0 +1,28 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+} from 'typeorm';
+
+@Entity()
+export class LPToken {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @Column()
+  poolId: number;
+
+  @Column('decimal', { precision: 18, scale: 8 })
+  amount: number;
+
+  @CreateDateColumn()
+  mintedAt: Date;
+
+  @Column({ unique: true })
+  tokenId: string;
+}

--- a/src/lp-token/lp-token.module.ts
+++ b/src/lp-token/lp-token.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LPToken } from './lp-token.entity';
+import { LpTokenService } from './lp-token.service';
+import { LpTokenController } from './lp-token.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([LPToken])],
+  providers: [LpTokenService],
+  controllers: [LpTokenController],
+})
+export class LpTokenModule {}

--- a/src/lp-token/lp-token.service.ts
+++ b/src/lp-token/lp-token.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { LPToken } from './lp-token.entity';
+import { v4 as uuidv4 } from 'uuid';
+import { MintLpTokenDto } from './dtos/mint-lp-token.dto';
+import { BurnLpTokenDto } from './dtos/burn-lp-token.dto';
+
+@Injectable()
+export class LpTokenService {
+  constructor(
+    @InjectRepository(LPToken)
+    private readonly lpTokenRepo: Repository<LPToken>
+  ) {}
+
+  async mint(userId: number, dto: MintLpTokenDto) {
+    const token = this.lpTokenRepo.create({
+      userId,
+      poolId: dto.poolId,
+      amount: dto.amount,
+      tokenId: uuidv4(),
+    });
+
+    return this.lpTokenRepo.save(token);
+  }
+
+  async burn(userId: number, dto: BurnLpTokenDto) {
+    const token = await this.lpTokenRepo.findOne({ where: { tokenId: dto.tokenId } });
+
+    if (!token) throw new NotFoundException('Token not found');
+    if (token.userId !== userId) throw new ForbiddenException('Unauthorized');
+    if (token.amount < dto.amount)
+      throw new ForbiddenException('Insufficient balance');
+
+    token.amount -= dto.amount;
+
+    if (token.amount === 0) {
+      await this.lpTokenRepo.remove(token);
+      return { message: 'Token fully burned and removed' };
+    } else {
+      return this.lpTokenRepo.save(token);
+    }
+  }
+
+  async findByUser(userId: number) {
+    return this.lpTokenRepo.find({ where: { userId } });
+  }
+}


### PR DESCRIPTION
Description:
This PR introduces the LP Token module, enabling users to mint, burn, and view Liquidity Provider (LP) tokens tied to specific risk pools. These tokens represent user contributions to the pool and can support future features like governance, yield, or staking.

Features Implemented:
LPToken Entity with fields: id, userId, poolId, amount, mintedAt, and tokenId (UUID).

API Endpoints:

POST /lp-token/mint: Mint LP tokens for a specific pool.

POST /lp-token/burn: Burn owned LP tokens (partial or full).

GET /lp-token/me: Fetch all LP tokens owned by the authenticated user.

DTOs for minting and burning tokens with validation.

Ownership and balance validation before burning.

Authentication guard to restrict access to authorized users only.

Security & Validation:
Users can only mint/burn tokens linked to their account.

Burn operation checks for ownership and sufficient balance.

Each LP token has a unique UUID identifier.

Technical Notes:
Scaffolded to support future on-chain migration (ERC-20/ERC-721).

Share ratios and yield logic can be integrated in future iterations.

Closes: #16 
Tested: Locally and confirmed working with authenticated endpoints.