### PR TITLE
feat: Standardize API error responses with global exception filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs-modules/mailer": "^2.0.2",
-        "@nestjs/common": "^11.0.1",
+        "@nestjs/common": "^11.1.3",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.0",
@@ -2640,12 +2640,12 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.0.tgz",
-      "integrity": "sha512-8MrajltjtIN6eW9cTpv+1IZogqz2Zsrc8YDt0LwQPUq8cSq0j50DETdQpPsNMeib+p9avkV41+NrzGk1z2o5Wg==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.3.tgz",
+      "integrity": "sha512-ogEK+GriWodIwCw6buQ1rpcH4Kx+G7YQ9EwuPySI3rS05pSdtQ++UhucjusSI9apNidv+QURBztJkRecwwJQXg==",
       "license": "MIT",
       "dependencies": {
-        "file-type": "20.4.1",
+        "file-type": "21.0.0",
         "iterare": "1.2.1",
         "load-esm": "1.0.2",
         "tslib": "2.8.1",
@@ -2656,8 +2656,8 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "class-transformer": "*",
-        "class-validator": "*",
+        "class-transformer": ">=0.4.1",
+        "class-validator": ">=0.13.2",
         "reflect-metadata": "^0.1.12 || ^0.2.0",
         "rxjs": "^7.1.0"
       },
@@ -7646,18 +7646,18 @@
       }
     },
     "node_modules/file-type": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.4.1.tgz",
-      "integrity": "sha512-hw9gNZXUfZ02Jo0uafWLaFVPter5/k2rfcrjFJJHX/77xtSDOfJuEFb6oKlFV86FLP1SuyHMW1PSk0U9M5tKkQ==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.0.0.tgz",
+      "integrity": "sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==",
       "license": "MIT",
       "dependencies": {
-        "@tokenizer/inflate": "^0.2.6",
-        "strtok3": "^10.2.0",
+        "@tokenizer/inflate": "^0.2.7",
+        "strtok3": "^10.2.2",
         "token-types": "^6.0.0",
         "uint8array-extras": "^1.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
@@ -12041,19 +12041,6 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
-    "node_modules/peek-readable": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-7.0.0.tgz",
-      "integrity": "sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -13876,13 +13863,12 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.2.2.tgz",
-      "integrity": "sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.1.tgz",
+      "integrity": "sha512-3JWEZM6mfix/GCJBBUrkA8p2Id2pBkyTkVCJKto55w080QBKZ+8R171fGrbiSp+yMO/u6F8/yUh7K4V9K+YCnw==",
       "license": "MIT",
       "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^7.0.0"
+        "@tokenizer/token": "^0.3.0"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@nestjs-modules/mailer": "^2.0.2",
-    "@nestjs/common": "^11.0.1",
+    "@nestjs/common": "^11.1.3",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.0",

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,61 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+/**
+ * Global exception filter for handling HTTP exceptions and standardizing API error responses.
+ * It catches all instances of HttpException and formats the response to include
+ * statusCode, message, and timestamp for consistent error reporting.
+ */
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+    //private readonly logger = new Logger(HttpExceptionFilter.name);
+    /**
+     * Catches an HttpException and transforms it into a standardized error response.
+     * @param exception The HttpException instance that was caught.
+     * @param host The ArgumentsHost object, providing access to the context (e.g., Request, Response).
+    */
+    catch(exception: HttpException, host: ArgumentsHost) {
+        // Get the HTTP context from the arguments host
+        const ctx = host.switchToHttp();
+        const response = ctx.getResponse<Response>();
+        const request = ctx.getRequest<Request>();
+
+        // Determine the HTTP status code from the exception, or default to internal server error
+        const status =
+        exception instanceof HttpException
+            ? exception.getStatus()
+            : HttpStatus.INTERNAL_SERVER_ERROR;
+
+        // Get the error response from the exception. It can be a string or an object.
+        const errorResponse = exception.getResponse();
+
+        // Determine the message for the error response.
+        // If errorResponse is an object and has a 'message' property, use that.
+        // Otherwise, use the exception's message or a default message.
+        const message =
+        typeof errorResponse === 'object' && 'message' in errorResponse
+            ? (errorResponse as any).message
+            : exception.message || 'Internal Server Error';
+
+        // Log error for debugging purposes
+        // this.logger.error(
+        //     `HTTP ${status} Error: ${message}`,
+        //     exception.stack,
+        //     `${request.method} ${request.url}`,
+        // );
+        
+        // Send the structured error response
+        response.status(status).json({
+            statusCode: status,
+            message: message,
+            timestamp: new Date().toISOString()
+        });
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,14 @@ import { NestFactory } from "@nestjs/core"
 import { ValidationPipe } from "@nestjs/common"
 import { AppModule } from "./app.module"
 import { setupSwagger } from "./config/swagger.config"
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
+
+  // Apply the global exception filter
+  // This ensures all unhandled exceptions are caught and formatted consistently.
+  app.useGlobalFilters(new HttpExceptionFilter());
 
   // Global validation pipe
   app.useGlobalPipes(


### PR DESCRIPTION
feat: Standardize API Error Responses with Global Filter

This Pull Request implements a global exception filter to standardize the format of all API error responses across the application.

A new `HttpExceptionFilter` has been created under `src/common/filters/http-exception.filter.ts`. This filter is globally applied in `src/main.ts` using `app.useGlobalFilters()`.

The filter ensures that any intercepted `HttpException` (including those implicitly created by NestJS from generic errors or validation pipe failures) will return a consistent JSON payload with the following keys:

```json
{
  "statusCode": <number>,
  "message": "<error_message>",
  "timestamp": "<ISO_date>"
}

Closes #22