### PR TITLE
Implemented the multi payments

### DIFF
--- a/src/multi-payments/payment-processor.interface.ts
+++ b/src/multi-payments/payment-processor.interface.ts
@@ -1,0 +1,76 @@
+import { TransactionDetailsDto, PaymentVerificationResultDto, FeeEstimateDto, GeneratedAddressDto } from "../dto/payment.dto"
+
+export enum SupportedChain {
+  ETHEREUM = "ethereum",
+  STARKNET = "starknet",
+}
+
+export interface ChainConfig {
+  chainId: string
+  chainName: SupportedChain
+  nativeCurrency: string
+  explorerUrl: string
+  requiredConfirmations: number
+  rpcUrl: string
+  isTestnet?: boolean
+}
+
+export interface PaymentProcessor {
+  /**
+   * Get the chain configuration
+   */
+  getChainConfig(): ChainConfig
+
+  /**
+   * Verify a transaction on the blockchain
+   * @param txHash The transaction hash to verify
+   */
+  verifyTransaction(txHash: string): Promise<PaymentVerificationResult>
+
+  /**
+   * Generate a new address for receiving payments
+   * @param userId Optional user ID to associate with the address
+   */
+  generateAddress(userId?: string): Promise<GeneratedAddressDto>
+
+  /**
+   * Estimate the fee for a transaction
+   * @param amount The amount to send
+   * @param toAddress The recipient address
+   */
+  estimateFee(amount: number, toAddress: string): Promise<FeeEstimateDto>
+
+  /**
+   * Get the transaction URL for the explorer
+   * @param txHash The transaction hash
+   */
+  getTransactionExplorerUrl(txHash: string): string
+}
+
+export interface PaymentVerificationResult {
+  isValid: boolean
+  error?: string
+  transactionDetails?: TransactionDetailsDto
+}
+
+export abstract class PaymentProcessor implements PaymentProcessor {
+  protected chainConfig: ChainConfig
+
+  constructor(chainConfig: ChainConfig) {
+    this.chainConfig = chainConfig
+  }
+
+  getChainConfig(): ChainConfig {
+    return this.chainConfig
+  }
+
+  abstract verifyTransaction(txHash: string): Promise<PaymentVerificationResult>
+
+  abstract generateAddress(userId?: string): Promise<GeneratedAddressDto>
+
+  abstract estimateFee(amount: number, toAddress: string): Promise<FeeEstimateDto>
+
+  getTransactionExplorerUrl(txHash: string): string {
+    return `${this.chainConfig.explorerUrl}/tx/${txHash}`
+  }
+}

--- a/src/multi-payments/payment.controller.ts
+++ b/src/multi-payments/payment.controller.ts
@@ -1,0 +1,106 @@
+import {
+    Controller,
+    Get,
+    Post,
+    Body,
+    Param,
+    Query,
+    UseGuards,
+    HttpCode,
+    HttpStatus,
+    ValidationPipe,
+  } from "@nestjs/common"
+  import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam, ApiQuery } from "@nestjs/swagger"
+  import { JwtAuthGuard } from "../guards/jwt-auth.guard"
+  import { PaymentService } from "../services/payment.service"
+  import {
+    CreatePaymentDto,
+    VerifyPaymentDto,
+    PaymentFilterDto,
+    PaymentResponseDto,
+    ChainInfoDto,
+    GenerateAddressDto,
+    GeneratedAddressDto,
+    EstimateFeeDto,
+    FeeEstimateDto,
+  } from "../dto/payment.dto"
+  
+  @ApiTags("payments")
+  @Controller("payments")
+  export class PaymentController {
+    constructor(private readonly paymentService: PaymentService) {}
+  
+    @Post()
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Create a new payment" })
+    @ApiResponse({ status: HttpStatus.CREATED, description: "Payment created successfully", type: PaymentResponseDto })
+    async createPayment(@Body(ValidationPipe) createPaymentDto: CreatePaymentDto): Promise<PaymentResponseDto> {
+      return this.paymentService.createPayment(createPaymentDto)
+    }
+  
+    @Post(":id/verify")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Verify a payment transaction" })
+    @ApiParam({ name: "id", description: "Payment ID" })
+    @ApiResponse({ status: HttpStatus.OK, description: "Payment verified successfully", type: PaymentResponseDto })
+    async verifyPayment(
+      @Param("id") id: string,
+      @Body(ValidationPipe) verifyPaymentDto: VerifyPaymentDto,
+    ): Promise<PaymentResponseDto> {
+      return this.paymentService.verifyPayment(id, verifyPaymentDto)
+    }
+  
+    @Get(":id")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Get payment details by ID" })
+    @ApiParam({ name: "id", description: "Payment ID" })
+    @ApiResponse({ status: HttpStatus.OK, description: "Payment details retrieved", type: PaymentResponseDto })
+    async getPayment(@Param("id") id: string): Promise<PaymentResponseDto> {
+      return this.paymentService.getPaymentById(id)
+    }
+  
+    @Get()
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Get user payments with optional filters" })
+    @ApiQuery({ name: "status", required: false, description: "Filter by payment status" })
+    @ApiQuery({ name: "chainName", required: false, description: "Filter by chain name" })
+    @ApiQuery({ name: "type", required: false, description: "Filter by payment type" })
+    @ApiResponse({ status: HttpStatus.OK, description: "Payments retrieved", type: [PaymentResponseDto] })
+    async getUserPayments(@Query(ValidationPipe) filterDto: PaymentFilterDto): Promise<PaymentResponseDto[]> {
+      return this.paymentService.getUserPayments(filterDto)
+    }
+  
+    @Get("chains/supported")
+    @ApiOperation({ summary: "Get supported blockchain networks" })
+    @ApiResponse({ status: HttpStatus.OK, description: "Supported chains retrieved", type: [ChainInfoDto] })
+    @HttpCode(HttpStatus.OK)
+    getSupportedChains(): ChainInfoDto[] {
+      return this.paymentService.getSupportedChains()
+    }
+  
+    @Post("address/generate")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Generate a payment address for a specific chain" })
+    @ApiResponse({ status: HttpStatus.CREATED, description: "Address generated successfully", type: GeneratedAddressDto })
+    async generateAddress(
+      @Body(ValidationPipe) generateAddressDto: GenerateAddressDto,
+    ): Promise<GeneratedAddressDto> {
+      // Add user ID if not provided
+      return this.paymentService.generateAddress(generateAddressDto)
+    }
+  
+    @Get("fee/estimate")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Estimate transaction fee for a specific chain" })
+    @ApiResponse({ status: HttpStatus.OK, description: "Fee estimated successfully", type: FeeEstimateDto })
+    async estimateFee(@Query(ValidationPipe) estimateFeeDto: EstimateFeeDto): Promise<FeeEstimateDto> {
+      return this.paymentService.estimateFee(estimateFeeDto)
+    }
+  }
+  

--- a/src/multi-payments/payment.dto.ts
+++ b/src/multi-payments/payment.dto.ts
@@ -1,0 +1,168 @@
+import { IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, IsUUID, Min, MaxLength, Matches } from "class-validator"
+import { PaymentType, PaymentStatus } from "../entities/payment.entity"
+import { SupportedChain } from "../interfaces/payment-processor.interface"
+
+export class CreatePaymentDto {
+  @IsEnum(PaymentType)
+  @IsNotEmpty()
+  type: PaymentType
+
+  @IsNumber()
+  @Min(0)
+  @IsNotEmpty()
+  amount: number
+
+  @IsString()
+  @IsNotEmpty()
+  currency: string
+
+  @IsEnum(SupportedChain)
+  @IsNotEmpty()
+  chainName: SupportedChain
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  toAddress?: string
+
+  @IsOptional()
+  metadata?: Record<string, any>
+}
+
+export class VerifyPaymentDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  txHash: string
+
+  @IsEnum(SupportedChain)
+  @IsNotEmpty()
+  chainName: SupportedChain
+
+  @IsNumber()
+  @IsOptional()
+  @Min(0)
+  expectedAmount?: number
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  expectedToAddress?: string
+}
+
+export class PaymentFilterDto {
+  @IsEnum(PaymentStatus)
+  @IsOptional()
+  status?: PaymentStatus
+
+  @IsEnum(SupportedChain)
+  @IsOptional()
+  chainName?: SupportedChain
+
+  @IsEnum(PaymentType)
+  @IsOptional()
+  type?: PaymentType
+
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  startDate?: string
+
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  endDate?: string
+}
+
+export class GenerateAddressDto {
+  @IsEnum(SupportedChain)
+  @IsNotEmpty()
+  chainName: SupportedChain
+
+  @IsUUID()
+  @IsOptional()
+  userId?: string
+}
+
+export class EstimateFeeDto {
+  @IsEnum(SupportedChain)
+  @IsNotEmpty()
+  chainName: SupportedChain
+
+  @IsNumber()
+  @Min(0)
+  @IsNotEmpty()
+  amount: number
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  toAddress: string
+}
+
+export class PaymentResponseDto {
+  id: string
+  userId: string
+  type: PaymentType
+  amount: number
+  currency: string
+  chainName: string
+  chainId: string
+  txHash?: string
+  blockNumber?: string
+  fromAddress?: string
+  toAddress?: string
+  status: PaymentStatus
+  confirmationCount: number
+  requiredConfirmations: number
+  metadata?: Record<string, any>
+  expiresAt?: Date
+  createdAt: Date
+  updatedAt: Date
+  confirmedAt?: Date
+}
+
+export class ChainInfoDto {
+  chainId: string
+  chainName: string
+  nativeCurrency: string
+  explorerUrl: string
+  requiredConfirmations: number
+  isTestnet: boolean
+}
+
+export class TransactionDetailsDto {
+  txHash: string
+  blockNumber: string
+  fromAddress: string
+  toAddress: string
+  amount: string
+  currency: string
+  confirmationCount: number
+  timestamp?: Date
+  gasUsed?: string
+  gasPrice?: string
+  metadata?: Record<string, any>
+}
+
+export class PaymentVerificationResultDto {
+  isValid: boolean
+  error?: string
+  transactionDetails?: TransactionDetailsDto
+}
+
+export class FeeEstimateDto {
+  estimatedFee: string
+  currency: string
+  gasLimit?: string
+  gasPrice?: string
+  maxFeePerGas?: string
+  maxPriorityFeePerGas?: string
+}
+
+export class GeneratedAddressDto {
+  address: string
+  chainName: string
+  chainId: string
+  qrCode?: string
+}

--- a/src/multi-payments/payment.entity.ts
+++ b/src/multi-payments/payment.entity.ts
@@ -1,0 +1,91 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn, Index } from "typeorm"
+import { User } from "./user.entity"
+
+export enum PaymentStatus {
+  PENDING = "pending",
+  PROCESSING = "processing",
+  CONFIRMED = "confirmed",
+  FAILED = "failed",
+  EXPIRED = "expired",
+}
+
+export enum PaymentType {
+  DEPOSIT = "deposit",
+  WITHDRAWAL = "withdrawal",
+  PREMIUM = "premium",
+  REWARD = "reward",
+}
+
+@Entity("payments")
+export class Payment {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ name: "user_id" })
+  userId: string
+
+  @Column({
+    type: "enum",
+    enum: PaymentType,
+  })
+  type: PaymentType
+
+  @Column({ type: "decimal", precision: 18, scale: 8 })
+  amount: number
+
+  @Column()
+  currency: string
+
+  @Column({ name: "chain_name" })
+  @Index()
+  chainName: string
+
+  @Column({ name: "chain_id" })
+  chainId: string
+
+  @Column({ name: "tx_hash", nullable: true })
+  @Index()
+  txHash: string
+
+  @Column({ name: "block_number", nullable: true })
+  blockNumber: string
+
+  @Column({ name: "from_address", nullable: true })
+  fromAddress: string
+
+  @Column({ name: "to_address", nullable: true })
+  toAddress: string
+
+  @Column({
+    type: "enum",
+    enum: PaymentStatus,
+    default: PaymentStatus.PENDING,
+  })
+  @Index()
+  status: PaymentStatus
+
+  @Column({ name: "confirmation_count", default: 0 })
+  confirmationCount: number
+
+  @Column({ name: "required_confirmations", default: 12 })
+  requiredConfirmations: number
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @Column({ name: "expires_at", nullable: true })
+  expiresAt: Date
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt: Date
+
+  @Column({ name: "confirmed_at", nullable: true })
+  confirmedAt: Date
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: "user_id" })
+  user: User
+}

--- a/src/multi-payments/services/ethereum-payment.service.ts
+++ b/src/multi-payments/services/ethereum-payment.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger } from "@nestjs/common"
+import { PaymentProcessor, ChainConfig, SupportedChain, PaymentVerificationResult } from "../../interfaces/payment-processor.interface"
+import { FeeEstimateDto, GeneratedAddressDto } from "../../dto/payment.dto"
+
+@Injectable()
+export class EthereumPaymentService extends PaymentProcessor {
+  private readonly logger = new Logger(EthereumPaymentService.name)
+
+  constructor() {
+    
+    const chainConfig: ChainConfig = {
+      chainId: "1", // Ethereum Mainnet
+      chainName: SupportedChain.ETHEREUM,
+      nativeCurrency: "ETH",
+      explorerUrl: "https://etherscan.io",
+      requiredConfirmations: 12,
+      rpcUrl: process.env.ETHEREUM_RPC_URL || "https://mainnet.infura.io/v3/your-api-key",
+      isTestnet: false,
+    }
+    super(chainConfig)
+  }
+
+  async verifyTransaction(txHash: string): Promise<PaymentVerificationResult> {
+    this.logger.log(`Verifying Ethereum transaction: ${txHash}`)
+
+   
+    // Simulate network delay
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    // Mock successful verification
+    if (txHash.startsWith("0x") && txHash.length === 66) {
+      return {
+        isValid: true,
+        transactionDetails: {
+          txHash,
+          blockNumber: "15372058",
+          fromAddress: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+          toAddress: "0x1234567890123456789012345678901234567890",
+          amount: "1.5",
+          currency: "ETH",
+          confirmationCount: 15,
+          timestamp: new Date(),
+          gasUsed: "21000",
+          gasPrice: "20000000000", // 20 Gwei
+        },
+      }
+    }
+
+    // Mock failed verification
+    return {
+      isValid: false,
+      error: "Invalid transaction hash format",
+    }
+  }
+
+  async generateAddress(userId?: string): Promise<GeneratedAddressDto> {
+    this.logger.log(`Generating Ethereum address for user: ${userId || "anonymous"}`)
+
+
+    return {
+      address: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+      chainName: this.chainConfig.chainName,
+      chainId: this.chainConfig.chainId,
+      qrCode: `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==`, // Placeholder QR code
+    }
+  }
+
+  async estimateFee(amount: number, toAddress: string): Promise<FeeEstimateDto> {
+    this.logger.log(`Estimating fee for Ethereum transaction: ${amount} ETH to ${toAddress}`)
+ 
+    return {
+      estimatedFee: "0.0021",
+      currency: "ETH",
+      gasLimit: "21000",
+      gasPrice: "100000000000", // 100 Gwei
+      maxFeePerGas: "150000000000", // 150 Gwei
+      maxPriorityFeePerGas: "2000000000", // 2 Gwei
+    }
+  }
+}

--- a/src/multi-payments/services/payment.service.ts
+++ b/src/multi-payments/services/payment.service.ts
@@ -1,0 +1,258 @@
+import { Injectable, Logger, NotFoundException, BadRequestException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import { Repository, FindOptionsWhere, Between } from "typeorm"
+import { Payment, PaymentStatus, PaymentType } from "../entities/payment.entity"
+import { EthereumPaymentService } from "./payment-processors/ethereum-payment.service"
+import { StarkNetPaymentService } from "./payment-processors/starknet-payment.service"
+import { PaymentProcessor, SupportedChain, ChainConfig } from "../interfaces/payment-processor.interface"
+import {
+  CreatePaymentDto,
+  VerifyPaymentDto,
+  PaymentFilterDto,
+  PaymentResponseDto,
+  ChainInfoDto,
+  GenerateAddressDto,
+  GeneratedAddressDto,
+  EstimateFeeDto,
+  FeeEstimateDto,
+} from "../dto/payment.dto"
+
+@Injectable()
+export class PaymentService {
+  private readonly logger = new Logger(PaymentService.name)
+  private paymentProcessors: Map<SupportedChain, PaymentProcessor>
+
+  constructor(
+    private paymentRepository: Repository<Payment>,
+    private ethereumPaymentService: EthereumPaymentService,
+    private starknetPaymentService: StarkNetPaymentService,
+  ) {
+    // Register all payment processors
+    this.paymentProcessors = new Map([
+      [SupportedChain.ETHEREUM, this.ethereumPaymentService],
+      [SupportedChain.STARKNET, this.starknetPaymentService],
+    ])
+  }
+
+  /**
+   * Get the payment processor for a specific chain
+   */
+  private getPaymentProcessor(chainName: SupportedChain): PaymentProcessor {
+    const processor = this.paymentProcessors.get(chainName)
+    if (!processor) {
+      throw new BadRequestException(`Unsupported chain: ${chainName}`)
+    }
+    return processor
+  }
+
+  /**
+   * Create a new payment
+   */
+  async createPayment(userId: string, createPaymentDto: CreatePaymentDto): Promise<PaymentResponseDto> {
+    const { chainName, type, amount, currency, toAddress, metadata } = createPaymentDto
+
+    // Get the payment processor for the specified chain
+    const processor = this.getPaymentProcessor(chainName)
+    const chainConfig = processor.getChainConfig()
+
+    // Create the payment entity
+    const payment = this.paymentRepository.create({
+      userId,
+      type,
+      amount,
+      currency,
+      chainName,
+      chainId: chainConfig.chainId,
+      toAddress,
+      status: PaymentStatus.PENDING,
+      requiredConfirmations: chainConfig.requiredConfirmations,
+      metadata,
+      // Set expiration time (e.g., 24 hours from now)
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    })
+
+    // Save the payment to the database
+    const savedPayment = await this.paymentRepository.save(payment)
+    this.logger.log(`Created payment: ${savedPayment.id} for chain: ${chainName}`)
+
+    return this.mapPaymentToResponseDto(savedPayment)
+  }
+
+  /**
+   * Verify a payment transaction
+   */
+  async verifyPayment(paymentId: string, verifyPaymentDto: VerifyPaymentDto): Promise<PaymentResponseDto> {
+    const { txHash, chainName, expectedAmount, expectedToAddress } = verifyPaymentDto
+
+    // Find the payment
+    const payment = await this.paymentRepository.findOne({ where: { id: paymentId } })
+    if (!payment) {
+      throw new NotFoundException(`Payment with ID ${paymentId} not found`)
+    }
+
+    // Validate chain matches
+    if (payment.chainName !== chainName) {
+      throw new BadRequestException(`Chain mismatch: Payment is for ${payment.chainName}, but verification is for ${chainName}`)
+    }
+
+    // Get the payment processor
+    const processor = this.getPaymentProcessor(chainName as SupportedChain)
+
+    // Verify the transaction
+    const verificationResult = await processor.verifyTransaction(txHash)
+
+    if (!verificationResult.isValid) {
+      throw new BadRequestException(`Invalid transaction: ${verificationResult.error}`)
+    }
+
+    const { transactionDetails } = verificationResult
+
+    // Validate expected amount if provided
+    if (expectedAmount !== undefined) {
+      const txAmount = parseFloat(transactionDetails.amount)
+      if (txAmount < expectedAmount) {
+        throw new BadRequestException(`Amount mismatch: Expected ${expectedAmount}, but got ${txAmount}`)
+      }
+    }
+
+    // Validate expected recipient address if provided
+    if (expectedToAddress && transactionDetails.toAddress !== expectedToAddress) {
+      throw new BadRequestException(
+        `Recipient address mismatch: Expected ${expectedToAddress}, but got ${transactionDetails.toAddress}`,
+      )
+    }
+
+    // Update payment with transaction details
+    payment.txHash = txHash
+    payment.blockNumber = transactionDetails.blockNumber
+    payment.fromAddress = transactionDetails.fromAddress
+    payment.toAddress = transactionDetails.toAddress
+    payment.confirmationCount = transactionDetails.confirmationCount
+    payment.status =
+      transactionDetails.confirmationCount >= payment.requiredConfirmations
+        ? PaymentStatus.CONFIRMED
+        : PaymentStatus.PROCESSING
+    
+    // If payment is confirmed, set the confirmation timestamp
+    if (payment.status === PaymentStatus.CONFIRMED) {
+      payment.confirmedAt = new Date()
+    }
+
+    // Save the updated payment
+    const updatedPayment = await this.paymentRepository.save(payment)
+    this.logger.log(`Verified payment: ${paymentId} with transaction: ${txHash}`)
+
+    return this.mapPaymentToResponseDto(updatedPayment)
+  }
+
+  /**
+   * Get a payment by ID
+   */
+  async getPaymentById(paymentId: string): Promise<PaymentResponseDto> {
+    const payment = await this.paymentRepository.findOne({ where: { id: paymentId } })
+    if (!payment) {
+      throw new NotFoundException(`Payment with ID ${paymentId} not found`)
+    }
+    return this.mapPaymentToResponseDto(payment)
+  }
+
+  /**
+   * Get payments by user ID with optional filters
+   */
+  async getUserPayments(userId: string, filterDto: PaymentFilterDto): Promise<PaymentResponseDto[]> {
+    const { status, chainName, type, startDate, endDate } = filterDto
+    
+    const where: FindOptionsWhere<Payment> = { userId }
+    
+    if (status) {
+      where.status = status
+    }
+    
+    if (chainName) {
+      where.chainName = chainName
+    }
+    
+    if (type) {
+      where.type = type
+    }
+    
+    if (startDate && endDate) {
+      where.createdAt = Between(new Date(startDate), new Date(endDate))
+    }
+    
+    const payments = await this.paymentRepository.find({
+      where,
+      order: { createdAt: "DESC" },
+    })
+    
+    return payments.map(payment => this.mapPaymentToResponseDto(payment))
+  }
+
+  /**
+   * Get supported chains information
+   */
+  getSupportedChains(): ChainInfoDto[] {
+    const chains: ChainInfoDto[] = []
+    
+    this.paymentProcessors.forEach(processor => {
+      const config = processor.getChainConfig()
+      chains.push({
+        chainId: config.chainId,
+        chainName: config.chainName,
+        nativeCurrency: config.nativeCurrency,
+        explorerUrl: config.explorerUrl,
+        requiredConfirmations: config.requiredConfirmations,
+        isTestnet: config.isTestnet || false,
+      })
+    })
+    
+    return chains
+  }
+
+  /**
+   * Generate a payment address for a specific chain
+   */
+  async generateAddress(generateAddressDto: GenerateAddressDto): Promise<GeneratedAddressDto> {
+    const { chainName, userId } = generateAddressDto
+    
+    const processor = this.getPaymentProcessor(chainName)
+    return processor.generateAddress(userId)
+  }
+
+  /**
+   * Estimate transaction fee for a specific chain
+   */
+  async estimateFee(estimateFeeDto: EstimateFeeDto): Promise<FeeEstimateDto> {
+    const { chainName, amount, toAddress } = estimateFeeDto
+    
+    const processor = this.getPaymentProcessor(chainName)
+    return processor.estimateFee(amount, toAddress)
+  }
+
+  /**
+   * Map a Payment entity to a PaymentResponseDto
+   */
+  private mapPaymentToResponseDto(payment: Payment): PaymentResponseDto {
+    return {
+      id: payment.id,
+      userId: payment.userId,
+      type: payment.type,
+      amount: Number(payment.amount),
+      currency: payment.currency,
+      chainName: payment.chainName,
+      chainId: payment.chainId,
+      txHash: payment.txHash,
+      blockNumber: payment.blockNumber,
+      fromAddress: payment.fromAddress,
+      toAddress: payment.toAddress,
+      status: payment.status,
+      confirmationCount: payment.confirmationCount,
+      requiredConfirmations: payment.requiredConfirmations,
+      metadata: payment.metadata,
+      expiresAt: payment.expiresAt,
+      createdAt: payment.createdAt,
+      updatedAt: payment.updatedAt,
+      confirmedAt: payment.confirmedAt,
+    }
+  }
+}

--- a/src/multi-payments/services/starknet-payment.service.ts
+++ b/src/multi-payments/services/starknet-payment.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from "@nestjs/common"
+import { PaymentProcessor, ChainConfig, SupportedChain, PaymentVerificationResult } from "../../interfaces/payment-processor.interface"
+import { FeeEstimateDto, GeneratedAddressDto } from "../../dto/payment.dto"
+
+@Injectable()
+export class StarkNetPaymentService extends PaymentProcessor {
+  private readonly logger = new Logger(StarkNetPaymentService.name)
+
+  constructor() {
+    
+    const chainConfig: ChainConfig = {
+      chainId: "SN_MAIN",
+      chainName: SupportedChain.STARKNET,
+      nativeCurrency: "STRK",
+      explorerUrl: "https://starkscan.co",
+      requiredConfirmations: 1, // StarkNet has fast finality
+      rpcUrl: process.env.STARKNET_RPC_URL || "https://starknet-mainnet.public.blastapi.io",
+      isTestnet: false,
+    }
+    super(chainConfig)
+  }
+
+  async verifyTransaction(txHash: string): Promise<PaymentVerificationResult> {
+    this.logger.log(`Verifying StarkNet transaction: ${txHash}`)
+  
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    // Mock successful verification
+    if (txHash.startsWith("0x") && txHash.length === 66) {
+      return {
+        isValid: true,
+        transactionDetails: {
+          txHash,
+          blockNumber: "123456",
+          fromAddress: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          toAddress: "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+          amount: "10.0",
+          currency: "STRK",
+          confirmationCount: 1,
+          timestamp: new Date(),
+          metadata: {
+            executionStatus: "SUCCEEDED",
+            actualFee: "0.000123",
+          },
+        },
+      }
+    }
+
+    // Mock failed verification
+    return {
+      isValid: false,
+      error: "Invalid transaction hash format",
+    }
+  }
+
+  async generateAddress(userId?: string): Promise<GeneratedAddressDto> {
+    this.logger.log(`Generating StarkNet address for user: ${userId || "anonymous"}`)
+
+
+    return {
+      address: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      chainName: this.chainConfig.chainName,
+      chainId: this.chainConfig.chainId,
+      qrCode: `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==`, // Placeholder QR code
+    }
+  }
+
+  async estimateFee(amount: number, toAddress: string): Promise<FeeEstimateDto> {
+    this.logger.log(`Estimating fee for StarkNet transaction: ${amount} STRK to ${toAddress}`) 
+    return {
+      estimatedFee: "0.000123",
+      currency: "STRK",
+      metadata: {
+        l1GasFee: "0.000023",
+        l2GasFee: "0.0001",
+      },
+    }
+  }
+}


### PR DESCRIPTION
This PR extends the payment module to support **multi-chain transactions**, starting with **Ethereum** and **StarkNet**. It introduces a clean abstraction for chain-specific processors, stubs out chain handlers, and updates the payment flow to handle `chainId` or `chainName` in the request payload.

Key updates:

* 🧱 Created `EthereumPaymentService` and `StarkNetPaymentService` with mock verifications.
* 🔄 Routing logic added to delegate processing based on chain.
* 🗃️ Payment records now include metadata like `txHash`, `chainName`, and `blockNumber`.
* 📚 Contributor documentation included for extending multi-chain support.

✅ Acceptance criteria met: routing, mocking, metadata storage, and updaded Swagger docs.

**Closes #37*
