### PR TITLE
fix(user): throw NotFoundException for missing user/wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,8 +127,7 @@
       "ts"
     ],
     "roots": [
-      "src",
-      "test"
+      "src"
     ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
+
+const mockUser = {
+  id: 'user-123',
+  walletAddress: 'GABC123',
+  reputationScore: 100,
+  trustScore: 90,
+  email: 'test@example.com',
+  profileData: {},
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockUserService = {
+  findById: jest.fn(),
+  findByWallet: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+};
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+      providers: [{ provide: UserService, useValue: mockUserService }],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+    jest.clearAllMocks();
+  });
+
+  describe('getUser', () => {
+    it('should return user data when user exists', async () => {
+      mockUserService.findById.mockResolvedValue(mockUser);
+      const result = await controller.getUser({ id: 'user-123' });
+      expect(result.id).toBe('user-123');
+      expect(result.walletAddress).toBe('GABC123');
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      mockUserService.findById.mockRejectedValue(
+        new NotFoundException('User with ID nonexistent not found'),
+      );
+      await expect(controller.getUser({ id: 'nonexistent' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('getUserByWallet', () => {
+    it('should throw NotFoundException when wallet address not found', async () => {
+      mockUserService.findByWallet.mockRejectedValue(
+        new NotFoundException('User with wallet address GXXX not found'),
+      );
+      await expect(controller.getUserByWallet('GXXX')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the error exposure issue in `UserController` where missing users returned `HTTP 200` with a plain `{ error: 'User not found' }` object.

### Changes
- Removed old `src/user.controller.ts` that returned `{ error: 'User not found' }` with HTTP 200
- Confirmed `src/user/user.controller.ts` delegates to `UserService` which throws `NotFoundException` for missing users, returning proper 404 responses
- Added `user.controller.spec.ts` covering `NotFoundException` for `getUser` and `getUserByWallet` endpoints
- Fixed jest roots config: removed missing `test` directory entry that blocked all unit test runs

### Before
```
GET /api/user/nonexistent-id
HTTP 200 OK
{ "error": "User not found" }
```

### After
```
GET /api/user/nonexistent-id
HTTP 404 Not Found
{
  "statusCode": 404,
  "message": "User with ID nonexistent-id not found",
  "error": "Not Found"
}
```

Closes #288