### PR TITLE
Fix invalid tsconfig compiler options blocking tsc build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "module": "commonjs",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
Closes #378 

Summary:
- Removed ignoreDeprecations from compilerOptions (unsupported option, caused TS5095)
- Changed moduleResolution from "bundler" to "node" since module is set to commonjs (mismatch caused TS5103)

These options were preventing tsc from starting type validation entirely, so `nest start -b tsc --watch` and `npx tsc -p tsconfig.build.json --noEmit` failed before any source files were checked.

Verification:
- Ran `npx tsc -p tsconfig.build.json --noEmit` — TS5095 and TS5103 no longer occur; tsc now proceeds to type-check source files.
