### PR TITLE
fix: enforce soft-delete everywhere and fix the hard-delete bypass in UserService

### DIFF
--- a/SOFT_DELETE_GUIDE.md
+++ b/SOFT_DELETE_GUIDE.md
@@ -31,6 +31,11 @@ The following models support soft delete (have `deletedAt` field):
 - AuditLog
 - LedgerCursor
 - ProcessedEvent
+- IndexerLog
+- NotificationSetting
+- Notification
+- EmailOutbox
+- IdempotencyKey
 
 ### Files Added
 

--- a/SOFT_DELETE_IMPLEMENTATION.md
+++ b/SOFT_DELETE_IMPLEMENTATION.md
@@ -67,6 +67,11 @@ Confirmed models:
 - AuditLog
 - LedgerCursor
 - ProcessedEvent
+- IndexerLog
+- NotificationSetting
+- Notification
+- EmailOutbox
+- IdempotencyKey
 
 ### Step 2: Ensure Migrations are Up-to-Date
 ```bash

--- a/SOFT_DELETE_SUMMARY.md
+++ b/SOFT_DELETE_SUMMARY.md
@@ -156,7 +156,7 @@ User deletes record
 ✅ Referential integrity preserved
 ```
 
-## 📋 Models Protected (13 Total)
+## 📋 Models Protected (18 Total)
 
 1. ✅ User
 2. ✅ Project
@@ -171,6 +171,11 @@ User deletes record
 11. ✅ AuditLog
 12. ✅ LedgerCursor
 13. ✅ ProcessedEvent
+14. ✅ IndexerLog
+15. ✅ NotificationSetting
+16. ✅ Notification
+17. ✅ EmailOutbox
+18. ✅ IdempotencyKey
 
 ## 🚀 Quick Start
 

--- a/src/common/interceptors/response.interceptor.spec.ts
+++ b/src/common/interceptors/response.interceptor.spec.ts
@@ -1,0 +1,70 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { firstValueFrom, of } from 'rxjs';
+import { ResponseTransformInterceptor } from './response.interceptor';
+
+describe('ResponseTransformInterceptor', () => {
+  const interceptor = new ResponseTransformInterceptor();
+  const context = {} as ExecutionContext;
+
+  const run = (body: unknown) =>
+    firstValueFrom(
+      interceptor.intercept(context, {
+        handle: () => of(body),
+      } as CallHandler),
+    );
+
+  it('wraps plain payloads in the success envelope', async () => {
+    await expect(run({ id: '1' })).resolves.toEqual({
+      success: true,
+      data: { id: '1' },
+    });
+  });
+
+  it('strips deletedAt from objects, nested objects and arrays', async () => {
+    const result = await run({
+      id: '1',
+      deletedAt: null,
+      profile: { name: 'Ada', deletedAt: new Date() },
+      items: [{ id: 'a', deletedAt: new Date() }],
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        id: '1',
+        profile: { name: 'Ada' },
+        items: [{ id: 'a' }],
+      },
+    });
+  });
+
+  it('preserves Date and other class instances while stripping around them', async () => {
+    const createdAt = new Date('2026-01-01T00:00:00.000Z');
+    const result = (await run({ createdAt, deletedAt: createdAt })) as {
+      data: { createdAt: Date };
+    };
+
+    expect(result.data).toEqual({ createdAt });
+    expect(result.data.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('leaves explicitly shaped success bodies untouched', async () => {
+    const deletedAt = new Date();
+    const body = { success: true, id: 'user-1', deletedAt };
+
+    await expect(run(body)).resolves.toBe(body);
+  });
+
+  it('preserves data/meta pagination envelopes', async () => {
+    const result = await run({
+      data: [{ id: '1', deletedAt: new Date() }],
+      meta: { page: 1 },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: [{ id: '1' }],
+      meta: { page: 1 },
+    });
+  });
+});

--- a/src/common/interceptors/response.interceptor.ts
+++ b/src/common/interceptors/response.interceptor.ts
@@ -35,9 +35,40 @@ export class ResponseTransformInterceptor implements NestInterceptor {
       'meta' in body
     ) {
       const { data, meta } = body as any;
-      return { success: true, data, meta };
+      return { success: true, data: this.stripSoftDeleteMetadata(data), meta };
     }
 
-    return { success: true, data: body };
+    return { success: true, data: this.stripSoftDeleteMetadata(body) };
+  }
+
+  /**
+   * Removes the internal `deletedAt` soft-delete marker from response
+   * payloads so it never leaks through the public API. Only plain objects
+   * and arrays are traversed; class instances (Date, Prisma.Decimal, ...)
+   * are returned untouched.
+   */
+  private stripSoftDeleteMetadata(value: unknown, depth = 0): unknown {
+    if (depth > 10 || value === null || typeof value !== 'object') {
+      return value;
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(item => this.stripSoftDeleteMetadata(item, depth + 1));
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return value;
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (key === 'deletedAt') {
+        continue;
+      }
+      result[key] = this.stripSoftDeleteMetadata(entry, depth + 1);
+    }
+
+    return result;
   }
 }

--- a/src/indexer/indexer.module.ts
+++ b/src/indexer/indexer.module.ts
@@ -5,6 +5,7 @@ import { IndexerService } from './services/indexer.service';
 import { LedgerTrackerService } from './services/ledger-tracker.service';
 import { EventHandlerService } from './services/event-handler.service';
 import { DatabaseModule } from '../database.module';
+import { SoftDeleteModule } from '../prisma.soft-delete.module';
 import stellarConfig, { indexerConfig } from '../config/stellar.config';
 
 /**
@@ -19,6 +20,8 @@ import stellarConfig, { indexerConfig } from '../config/stellar.config';
     ScheduleModule.forRoot(),
     // Database access
     DatabaseModule,
+    // Audited hard-delete utilities (re-org rollback purges)
+    SoftDeleteModule,
     // Configuration
     ConfigModule.forFeature(stellarConfig),
     ConfigModule.forFeature(indexerConfig),

--- a/src/indexer/services/ledger-tracker.service.ts
+++ b/src/indexer/services/ledger-tracker.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../prisma.service';
+import { SoftDeleteService } from '../../prisma.soft-delete.service';
 import { LedgerCursor, LedgerInfo, ReorgDetectionResult } from '../types/ledger.types';
 
 /**
@@ -14,6 +15,7 @@ export class LedgerTrackerService {
 
   constructor(
     private readonly prisma: PrismaService,
+    private readonly softDelete: SoftDeleteService,
     private readonly configService: ConfigService,
   ) {
     this.network = this.configService.get<string>('STELLAR_NETWORK', 'testnet');
@@ -175,15 +177,20 @@ export class LedgerTrackerService {
 
     const safeLedgerSeq = Math.max(0, reorgResult.lastValidLedger - rollbackDepth);
 
-    // Delete processed events from the rolled-back ledgers
-    await this.prisma.processedEvent.deleteMany({
-      where: {
+    // Purge processed events from the rolled-back ledgers. This must be an
+    // explicit hard delete: eventId is unique, so a soft-deleted row would
+    // keep holding the key and block the event from being re-processed after
+    // the rollback. SoftDeleteService logs and audit-trails the purge.
+    await this.softDelete.hardDeleteMany(
+      'processedEvent',
+      {
         network: this.network,
         ledgerSeq: {
           gt: safeLedgerSeq,
         },
       },
-    });
+      `Blockchain re-org rollback to ledger ${safeLedgerSeq}`,
+    );
 
     this.logger.log(`Deleted processed events after ledger ${safeLedgerSeq}`);
 

--- a/src/interceptors/idempotency.interceptor.ts
+++ b/src/interceptors/idempotency.interceptor.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { Observable, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma.service';
 
 @Injectable()
@@ -33,41 +34,58 @@ export class IdempotencyInterceptor implements NestInterceptor {
         where: { key: idempotencyKey },
       });
 
-      if (existingKey) {
-        // Check if key has expired
-        if (new Date() > existingKey.expiresAt) {
-          // Key expired, delete it and allow request to proceed
-          await this.prisma.idempotencyKey.delete({
-            where: { key: idempotencyKey },
-          });
-        } else if (existingKey.status === 'COMPLETED' && existingKey.response) {
-          // Return cached response
-          response.set('X-Idempotency-Key', idempotencyKey);
-          response.set('X-Idempotency-Replayed', 'true');
-          return of(existingKey.response);
-        } else if (existingKey.status === 'PENDING') {
-          // Request is being processed, return 409 Conflict
-          throw new HttpException(
-            'Request is still being processed. Please wait and retry.',
-            HttpStatus.CONFLICT,
-          );
-        }
-      }
-
-      // Create new idempotency key record
       const expiresAt = new Date();
       expiresAt.setHours(expiresAt.getHours() + 24); // 24-hour TTL
 
-      await this.prisma.idempotencyKey.create({
-        data: {
-          key: idempotencyKey,
-          method,
-          endpoint,
-          requestBody: request.body || {},
-          status: 'PENDING',
-          expiresAt,
-        },
-      });
+      if (existingKey) {
+        const isExpired = new Date() > existingKey.expiresAt;
+
+        if (!isExpired) {
+          if (existingKey.status === 'COMPLETED' && existingKey.response) {
+            // Return cached response
+            response.set('X-Idempotency-Key', idempotencyKey);
+            response.set('X-Idempotency-Replayed', 'true');
+            return of(existingKey.response);
+          }
+
+          if (existingKey.status === 'PENDING') {
+            // Request is being processed, return 409 Conflict
+            throw new HttpException(
+              'Request is still being processed. Please wait and retry.',
+              HttpStatus.CONFLICT,
+            );
+          }
+        }
+
+        // Key expired or previous attempt failed: reset the record in place.
+        // IdempotencyKey is a soft-delete model, so delete + recreate would
+        // leave a soft-deleted row holding the unique key and the recreate
+        // would fail with a unique constraint violation.
+        await this.prisma.idempotencyKey.update({
+          where: { key: idempotencyKey },
+          data: {
+            method,
+            endpoint,
+            requestBody: request.body || {},
+            response: Prisma.DbNull,
+            status: 'PENDING',
+            expiresAt,
+            deletedAt: null,
+          },
+        });
+      } else {
+        // Create new idempotency key record
+        await this.prisma.idempotencyKey.create({
+          data: {
+            key: idempotencyKey,
+            method,
+            endpoint,
+            requestBody: request.body || {},
+            status: 'PENDING',
+            expiresAt,
+          },
+        });
+      }
 
       // Process the request
       return next.handle().pipe(

--- a/src/notification/notification.controller.spec.ts
+++ b/src/notification/notification.controller.spec.ts
@@ -1,5 +1,22 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { NotificationController } from './notification.controller';
+import { PrismaService } from '../prisma.service';
+import { EncryptionService } from '../encryption/encryption.service';
+
+const prisma = {
+  user: {
+    findFirst: jest.fn(),
+    update: jest.fn(),
+  },
+  notificationSetting: {
+    upsert: jest.fn(),
+  },
+};
+
+const encryption = {
+  encrypt: jest.fn((value: string) => `encrypted:${value}`),
+};
 
 describe('NotificationController', () => {
   let controller: NotificationController;
@@ -7,12 +24,110 @@ describe('NotificationController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [NotificationController],
+      providers: [
+        { provide: PrismaService, useValue: prisma },
+        { provide: EncryptionService, useValue: encryption },
+      ],
     }).compile();
 
     controller = module.get<NotificationController>(NotificationController);
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getSettings', () => {
+    it('returns settings for an active user and restores a soft-deleted row', async () => {
+      prisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
+      prisma.notificationSetting.upsert.mockResolvedValue({
+        userId: 'user-1',
+        emailEnabled: true,
+      });
+
+      await controller.getSettings('user-1');
+
+      expect(prisma.user.findFirst).toHaveBeenCalledWith({
+        where: { id: 'user-1', deletedAt: null },
+        select: { id: true },
+      });
+      expect(prisma.notificationSetting.upsert).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        update: { deletedAt: null },
+        create: { userId: 'user-1' },
+      });
+    });
+
+    it('rejects soft-deleted or unknown users with 404', async () => {
+      prisma.user.findFirst.mockResolvedValue(null);
+
+      await expect(controller.getSettings('user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.notificationSetting.upsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('updates settings for an active user, clearing any soft-delete marker', async () => {
+      prisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
+      prisma.notificationSetting.upsert.mockResolvedValue({
+        userId: 'user-1',
+        emailEnabled: false,
+      });
+
+      await controller.updateSettings('user-1', { emailEnabled: false });
+
+      expect(prisma.notificationSetting.upsert).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        update: { emailEnabled: false, deletedAt: null },
+        create: { userId: 'user-1', emailEnabled: false },
+      });
+    });
+
+    it('rejects soft-deleted or unknown users with 404', async () => {
+      prisma.user.findFirst.mockResolvedValue(null);
+
+      await expect(
+        controller.updateSettings('user-1', { emailEnabled: false }),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.notificationSetting.upsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('subscribeToPush', () => {
+    const subscription = {
+      endpoint: 'https://push.example.com/sub',
+      keys: {
+        p256dh: Buffer.from('p256dh-key').toString('base64'),
+        auth: Buffer.from('auth-key').toString('base64'),
+      },
+    };
+
+    it('stores the encrypted subscription for an active user', async () => {
+      prisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
+      prisma.user.update.mockResolvedValue({ id: 'user-1' });
+
+      await expect(
+        controller.subscribeToPush('user-1', subscription),
+      ).resolves.toEqual({ success: true });
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: {
+          pushSubscription: `encrypted:${JSON.stringify(subscription)}`,
+        },
+      });
+    });
+
+    it('rejects soft-deleted or unknown users with 404', async () => {
+      prisma.user.findFirst.mockResolvedValue(null);
+
+      await expect(
+        controller.subscribeToPush('user-1', subscription),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.user.update).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Param, Post, Put, BadRequestException } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    Post,
+    Put,
+    BadRequestException,
+    NotFoundException,
+} from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import {
   ApiTags,
@@ -27,9 +36,14 @@ export class NotificationController {
     @ApiParam({ name: 'userId', type: String, description: 'ID of the user' })
     @ApiOkResponse({ description: 'Notification settings for the user' })
     async getSettings(@Param('userId') userId: string) {
+        await this.ensureActiveUser(userId);
+
         return this.prisma.notificationSetting.upsert({
             where: { userId },
-            update: {},
+            // upsert bypasses the soft-delete middleware, so restore the row
+            // explicitly: an active user must always see usable settings even
+            // if they were previously soft-deleted (e.g. restored account).
+            update: { deletedAt: null },
             create: { userId },
         });
     }
@@ -44,9 +58,11 @@ export class NotificationController {
         @Param('userId') userId: string,
         @Body() settings: UpdateNotificationSettingsDto,
     ) {
+        await this.ensureActiveUser(userId);
+
         return this.prisma.notificationSetting.upsert({
             where: { userId },
-            update: settings,
+            update: { ...settings, deletedAt: null },
             create: {
                 userId,
                 ...settings,
@@ -88,6 +104,8 @@ export class NotificationController {
             throw new BadRequestException('Invalid key encoding');
         }
 
+        await this.ensureActiveUser(userId);
+
         // Encrypt push subscription before storing
         const encryptedSubscription = this.encryption.encrypt(JSON.stringify(subscription));
         await this.prisma.user.update({
@@ -95,5 +113,20 @@ export class NotificationController {
             data: { pushSubscription: encryptedSubscription },
         });
         return { success: true };
+    }
+
+    /**
+     * Rejects requests targeting missing or soft-deleted users with a 404
+     * instead of silently operating on (or resurrecting) their records.
+     */
+    private async ensureActiveUser(userId: string): Promise<void> {
+        const user = await this.prisma.user.findFirst({
+            where: { id: userId, deletedAt: null },
+            select: { id: true },
+        });
+
+        if (!user) {
+            throw new NotFoundException(`User with ID ${userId} not found`);
+        }
     }
 }

--- a/src/prisma.soft-delete.middleware.spec.ts
+++ b/src/prisma.soft-delete.middleware.spec.ts
@@ -1,0 +1,186 @@
+import { Prisma } from '@prisma/client';
+import {
+  createSoftDeleteMiddleware,
+  SOFT_DELETE_MODELS,
+} from './prisma.soft-delete.middleware';
+
+type MiddlewareParams = Prisma.MiddlewareParams;
+
+function buildParams(
+  overrides: Partial<MiddlewareParams>,
+): MiddlewareParams {
+  return {
+    model: 'User',
+    action: 'findMany',
+    args: {},
+    dataPath: [],
+    runInTransaction: false,
+    ...overrides,
+  } as MiddlewareParams;
+}
+
+describe('createSoftDeleteMiddleware', () => {
+  const middleware = createSoftDeleteMiddleware({ excludeDeleted: true });
+  let next: jest.Mock;
+
+  beforeEach(() => {
+    next = jest.fn().mockResolvedValue('result');
+  });
+
+  describe('model coverage', () => {
+    it.each([
+      'Notification',
+      'NotificationSetting',
+      'EmailOutbox',
+      'IdempotencyKey',
+      'IndexerLog',
+    ])('includes %s in SOFT_DELETE_MODELS', model => {
+      expect(SOFT_DELETE_MODELS).toContain(model);
+    });
+
+    it('covers every model defined in the Prisma schema', () => {
+      expect([...SOFT_DELETE_MODELS].sort()).toEqual(
+        [...Object.values(Prisma.ModelName)].sort(),
+      );
+    });
+
+    it('leaves models outside the soft-delete list untouched', async () => {
+      const params = buildParams({
+        model: 'SomethingElse' as Prisma.ModelName,
+        action: 'delete',
+        args: { where: { id: '1' } },
+      });
+
+      await middleware(params, next);
+
+      expect(next).toHaveBeenCalledWith(params);
+      expect(next.mock.calls[0][0].action).toBe('delete');
+    });
+  });
+
+  describe('read operations', () => {
+    it('filters soft-deleted rows out of findMany by default', async () => {
+      const params = buildParams({
+        action: 'findMany',
+        args: { where: { walletAddress: 'GABC' } },
+      });
+
+      await middleware(params, next);
+
+      expect(next.mock.calls[0][0].args.where).toEqual({
+        walletAddress: 'GABC',
+        deletedAt: null,
+      });
+    });
+
+    it('honours includeDeleted and strips the flag before the query runs', async () => {
+      const params = buildParams({
+        action: 'findMany',
+        args: { where: { _includeDeleted: true } },
+      });
+
+      await middleware(params, next);
+
+      expect(next.mock.calls[0][0].args.where).toEqual({});
+    });
+
+    it('filters soft-deleted rows out of count by default', async () => {
+      const params = buildParams({ action: 'count', args: {} });
+
+      await middleware(params, next);
+
+      expect(next.mock.calls[0][0].args.where).toEqual({ deletedAt: null });
+    });
+  });
+
+  describe('delete conversion', () => {
+    it('converts delete into an update that stamps deletedAt', async () => {
+      const params = buildParams({
+        action: 'delete',
+        args: { where: { id: 'user-1' } },
+      });
+
+      await middleware(params, next);
+
+      const forwarded = next.mock.calls[0][0];
+      expect(forwarded.action).toBe('update');
+      expect(forwarded.args).toEqual({
+        where: { id: 'user-1', deletedAt: null },
+        data: { deletedAt: expect.any(Date) },
+      });
+    });
+
+    it('converts deleteMany into updateMany scoped to active rows', async () => {
+      const params = buildParams({
+        model: 'Notification' as Prisma.ModelName,
+        action: 'deleteMany',
+        args: { where: { userId: 'user-1' } },
+      });
+
+      await middleware(params, next);
+
+      const forwarded = next.mock.calls[0][0];
+      expect(forwarded.action).toBe('updateMany');
+      expect(forwarded.args).toEqual({
+        where: { userId: 'user-1', deletedAt: null },
+        data: { deletedAt: expect.any(Date) },
+      });
+    });
+  });
+
+  describe('audited hard-delete escape hatch', () => {
+    it('lets an explicit hardDelete flag through as a real delete', async () => {
+      const params = buildParams({
+        action: 'delete',
+        args: { where: { id: 'user-1' }, hardDelete: true },
+      });
+
+      await middleware(params, next);
+
+      const forwarded = next.mock.calls[0][0];
+      expect(forwarded.action).toBe('delete');
+      expect(forwarded.args).toEqual({ where: { id: 'user-1' } });
+    });
+
+    it('supports the _hardDelete flag inside where and strips it', async () => {
+      const params = buildParams({
+        model: 'ProcessedEvent' as Prisma.ModelName,
+        action: 'deleteMany',
+        args: { where: { network: 'testnet', _hardDelete: true } },
+      });
+
+      await middleware(params, next);
+
+      const forwarded = next.mock.calls[0][0];
+      expect(forwarded.action).toBe('deleteMany');
+      expect(forwarded.args).toEqual({ where: { network: 'testnet' } });
+    });
+  });
+
+  describe('update operations', () => {
+    it('scopes regular updates to active rows', async () => {
+      const params = buildParams({
+        action: 'update',
+        args: { where: { id: 'user-1' }, data: { email: 'a@b.c' } },
+      });
+
+      await middleware(params, next);
+
+      expect(next.mock.calls[0][0].args.where).toEqual({
+        id: 'user-1',
+        deletedAt: null,
+      });
+    });
+
+    it('allows restores (deletedAt: null) to reach soft-deleted rows', async () => {
+      const params = buildParams({
+        action: 'update',
+        args: { where: { id: 'user-1' }, data: { deletedAt: null } },
+      });
+
+      await middleware(params, next);
+
+      expect(next.mock.calls[0][0].args.where).toEqual({ id: 'user-1' });
+    });
+  });
+});

--- a/src/prisma.soft-delete.middleware.ts
+++ b/src/prisma.soft-delete.middleware.ts
@@ -17,6 +17,11 @@ export const SOFT_DELETE_MODELS = [
   'AuditLog',
   'LedgerCursor',
   'ProcessedEvent',
+  'IndexerLog',
+  'NotificationSetting',
+  'Notification',
+  'EmailOutbox',
+  'IdempotencyKey',
 ] as const;
 
 export type SoftDeleteModel = (typeof SOFT_DELETE_MODELS)[number];
@@ -36,11 +41,13 @@ type MiddlewareNext = (params: Prisma.MiddlewareParams) => Promise<unknown>;
 
 type SoftDeleteWhere = Record<string, unknown> & {
   _includeDeleted?: boolean;
+  _hardDelete?: boolean;
 };
 
 interface SoftDeleteMiddlewareArgs {
   where?: SoftDeleteWhere;
   includeDeleted?: boolean;
+  hardDelete?: boolean;
   data?: Record<string, unknown>;
 }
 
@@ -92,8 +99,12 @@ export function createSoftDeleteMiddleware(
 
     // Handle update operations - prevent updating through relations
     if (action === 'update' || action === 'updateMany') {
+      // Restore operations (data.deletedAt === null) must be able to reach
+      // soft-deleted rows, otherwise a deleted record could never be recovered.
+      const isRestore = args.data?.deletedAt === null;
+
       // Only update non-deleted records
-      if (config.excludeDeleted) {
+      if (config.excludeDeleted && !isRestore) {
         args.where = {
           ...args.where,
           deletedAt: null,
@@ -103,9 +114,23 @@ export function createSoftDeleteMiddleware(
 
     // Handle delete operations - convert to soft delete
     if (action === 'delete' || action === 'deleteMany') {
-      // Convert delete to update with deletedAt timestamp
+      // Explicit, audited purge paths (e.g. SoftDeleteService.hardDelete,
+      // GDPR erasure, re-org rollbacks) may opt out of the conversion.
+      if (shouldHardDelete(args)) {
+        removeHardDeleteFlags(args);
+        return next(params);
+      }
+
+      removeHardDeleteFlags(args);
+
+      // Convert delete to update with deletedAt timestamp.
+      // Only touch rows that are not already soft-deleted so repeated
+      // deletes do not silently re-stamp deletedAt.
       const updateArgs = {
-        where: args.where,
+        where: {
+          ...args.where,
+          deletedAt: null,
+        },
         data: {
           deletedAt: new Date(),
         },
@@ -163,6 +188,19 @@ function getMiddlewareArgs(
 
 function shouldIncludeDeleted(args: SoftDeleteMiddlewareArgs): boolean {
   return args.where?._includeDeleted === true || args.includeDeleted === true;
+}
+
+function shouldHardDelete(args: SoftDeleteMiddlewareArgs): boolean {
+  return args.where?._hardDelete === true || args.hardDelete === true;
+}
+
+function removeHardDeleteFlags(args: SoftDeleteMiddlewareArgs): void {
+  if (args.where?._hardDelete !== undefined) {
+    delete args.where._hardDelete;
+  }
+  if (args.hardDelete !== undefined) {
+    delete args.hardDelete;
+  }
 }
 
 function removeIncludeDeletedFlags(args: SoftDeleteMiddlewareArgs): void {

--- a/src/prisma.soft-delete.service.ts
+++ b/src/prisma.soft-delete.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { AuditAction, Prisma } from '@prisma/client';
 import { PrismaService } from './prisma.service';
 import type { SoftDeleteModel } from './prisma.soft-delete.middleware';
 
@@ -12,9 +13,13 @@ interface QueryOptions {
 }
 
 interface SoftDeleteDelegate {
-  delete<T>(args: { where: Record<string, unknown> }): Promise<T>;
+  delete<T>(args: {
+    where: Record<string, unknown>;
+    hardDelete?: boolean;
+  }): Promise<T>;
   deleteMany(args: {
     where: Record<string, unknown>;
+    hardDelete?: boolean;
   }): Promise<{ count: number }>;
   update<T>(args: {
     where: Record<string, unknown>;
@@ -61,7 +66,16 @@ export class SoftDeleteService {
       `Hard deleting ${model as string} with where: ${JSON.stringify(where)}. Reason: ${reason || 'Not provided'}`,
     );
 
-    return this.getDelegate(model).delete<T>({ where });
+    // hardDelete: true opts out of the middleware's delete -> soft-delete
+    // conversion; without it this purge would silently become a soft delete.
+    const result = await this.getDelegate(model).delete<T>({
+      where,
+      hardDelete: true,
+    });
+
+    await this.recordPurgeAudit(model, where, reason);
+
+    return result;
   }
 
   /**
@@ -72,7 +86,7 @@ export class SoftDeleteService {
    * @param where - Filter conditions
    * @param reason - Audit reason for permanent deletion
    */
-  async hardDeleteMany<T>(
+  async hardDeleteMany(
     model: SoftDeleteDelegateName,
     where: Record<string, unknown>,
     reason?: string,
@@ -81,7 +95,14 @@ export class SoftDeleteService {
       `Hard deleting ${model as string} records. Reason: ${reason || 'Not provided'}`,
     );
 
-    return this.getDelegate(model).deleteMany({ where });
+    const result = await this.getDelegate(model).deleteMany({
+      where,
+      hardDelete: true,
+    });
+
+    await this.recordPurgeAudit(model, where, reason, result.count);
+
+    return result;
   }
 
   /**
@@ -214,14 +235,24 @@ export class SoftDeleteService {
       `Permanently deleting ${model as string} records deleted before ${deletedBefore.toISOString()}`,
     );
 
-    const result = await this.getDelegate(model).deleteMany({
-      where: {
-        deletedAt: {
-          not: null,
-          lt: deletedBefore,
-        },
+    const where = {
+      deletedAt: {
+        not: null,
+        lt: deletedBefore,
       },
+    };
+
+    const result = await this.getDelegate(model).deleteMany({
+      where,
+      hardDelete: true,
     });
+
+    await this.recordPurgeAudit(
+      model,
+      where,
+      `Retention cleanup of records soft-deleted before ${deletedBefore.toISOString()}`,
+      result.count,
+    );
 
     return result.count;
   }
@@ -249,5 +280,35 @@ export class SoftDeleteService {
 
   private getDelegate(model: SoftDeleteDelegateName): SoftDeleteDelegate {
     return this.prisma[model] as unknown as SoftDeleteDelegate;
+  }
+
+  /**
+   * Record an audit trail entry for a permanent deletion.
+   * Best-effort: a failed audit write is logged but does not fail the purge.
+   */
+  private async recordPurgeAudit(
+    model: SoftDeleteDelegateName,
+    where: Record<string, unknown>,
+    reason?: string,
+    count?: number,
+  ): Promise<void> {
+    try {
+      await this.prisma.auditLog.create({
+        data: {
+          action: AuditAction.DELETE,
+          entityType: model as string,
+          entityId: typeof where.id === 'string' ? where.id : 'bulk',
+          beforeState: JSON.parse(
+            JSON.stringify({ where, ...(count !== undefined && { count }) }),
+          ) as Prisma.InputJsonValue,
+          reason: reason || 'Hard delete (no reason provided)',
+        },
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to write audit log for hard delete of ${model as string}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
   }
 }

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -58,9 +58,9 @@ describe('UserController', () => {
       mockUserService.findByWallet.mockRejectedValue(
         new NotFoundException('User with wallet address GXXX not found'),
       );
-      await expect(controller.getUserByWallet('GXXX')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        controller.getUserByWallet({ address: 'GXXX' }),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -16,6 +16,21 @@ const prisma = {
     create: jest.fn(),
     update: jest.fn(),
   },
+  notification: {
+    updateMany: jest.fn(),
+  },
+  notificationSetting: {
+    updateMany: jest.fn(),
+  },
+  insurancePolicy: {
+    updateMany: jest.fn(),
+  },
+  claim: {
+    updateMany: jest.fn(),
+  },
+  $transaction: jest.fn((operations: Promise<unknown>[]) =>
+    Promise.all(operations),
+  ),
 };
 
 const encryption = {
@@ -120,6 +135,10 @@ describe('UserService', () => {
       id: 'clabcdefghij',
       deletedAt: new Date('2026-04-24T00:00:00.000Z'),
     });
+    prisma.notification.updateMany.mockResolvedValue({ count: 2 });
+    prisma.notificationSetting.updateMany.mockResolvedValue({ count: 1 });
+    prisma.insurancePolicy.updateMany.mockResolvedValue({ count: 1 });
+    prisma.claim.updateMany.mockResolvedValue({ count: 1 });
 
     const result = await service.delete('clabcdefghij');
 
@@ -133,6 +152,67 @@ describe('UserService', () => {
       id: 'clabcdefghij',
       deletedAt: new Date('2026-04-24T00:00:00.000Z'),
     });
+  });
+
+  it('cascades the soft delete to related records in one transaction', async () => {
+    prisma.user.findFirst.mockResolvedValue({
+      id: 'clabcdefghij',
+      walletAddress: 'encrypted:GABC123',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    prisma.user.update.mockResolvedValue({
+      id: 'clabcdefghij',
+      deletedAt: new Date('2026-04-24T00:00:00.000Z'),
+    });
+    prisma.notification.updateMany.mockResolvedValue({ count: 2 });
+    prisma.notificationSetting.updateMany.mockResolvedValue({ count: 1 });
+    prisma.insurancePolicy.updateMany.mockResolvedValue({ count: 1 });
+    prisma.claim.updateMany.mockResolvedValue({ count: 1 });
+
+    await service.delete('clabcdefghij');
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.notification.updateMany).toHaveBeenCalledWith({
+      where: { userId: 'clabcdefghij' },
+      data: { deletedAt: expect.any(Date) },
+    });
+    expect(prisma.notificationSetting.updateMany).toHaveBeenCalledWith({
+      where: { userId: 'clabcdefghij' },
+      data: { deletedAt: expect.any(Date) },
+    });
+    expect(prisma.insurancePolicy.updateMany).toHaveBeenCalledWith({
+      where: { userId: 'clabcdefghij' },
+      data: { deletedAt: expect.any(Date) },
+    });
+    expect(prisma.claim.updateMany).toHaveBeenCalledWith({
+      where: { policy: { userId: 'clabcdefghij' } },
+      data: { deletedAt: expect.any(Date) },
+    });
+
+    // Every cascaded record must share the exact same deletion timestamp
+    // so the whole cascade can be restored as a unit.
+    const userDeletedAt = prisma.user.update.mock.calls[0][0].data.deletedAt;
+    for (const delegate of [
+      prisma.notification,
+      prisma.notificationSetting,
+      prisma.insurancePolicy,
+      prisma.claim,
+    ]) {
+      expect(delegate.updateMany.mock.calls[0][0].data.deletedAt).toBe(
+        userDeletedAt,
+      );
+    }
+  });
+
+  it('refuses to delete a user that is missing or already soft-deleted', async () => {
+    prisma.user.findFirst.mockResolvedValue(null);
+
+    await expect(service.delete('clabcdefghij')).rejects.toThrow(
+      NotFoundException,
+    );
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.user.update).not.toHaveBeenCalled();
   });
 
   it('rejects invalid wallet address format in create', async () => {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -15,7 +15,7 @@ import {
 } from '../common/utils/sanitization.util';
 import { Prisma, User } from '@prisma/client';
 
-interface PaginatedUsers {
+export interface PaginatedUsers {
   data: User[];
   meta: {
     page: number;
@@ -38,9 +38,13 @@ export class UserService {
       throw new BadRequestException('Invalid user ID format');
     }
 
+    // The soft-delete middleware already filters deleted rows; the explicit
+    // deletedAt filter is defense-in-depth so this query stays correct even
+    // if the middleware is bypassed or misconfigured.
     const user = await this.prisma.user.findFirst({
       where: {
         id,
+        deletedAt: null,
       },
     });
     if (!user) {
@@ -61,6 +65,7 @@ export class UserService {
     const user = await this.prisma.user.findFirst({
       where: {
         walletAddress: sanitizedAddress,
+        deletedAt: null,
       },
     });
     if (!user) {
@@ -78,10 +83,12 @@ export class UserService {
 
     const [users, total] = await Promise.all([
       this.prisma.user.findMany({
+        where: { deletedAt: null },
         skip: offset,
         take: safeLimit,
       }),
       this.prisma.user.count({
+        where: { deletedAt: null },
       }),
     ]);
 
@@ -165,11 +172,45 @@ export class UserService {
     });
   }
 
+  /**
+   * Soft-deletes a user and cascades the soft delete to their related
+   * records (notifications, notification settings, insurance policies and
+   * the claims on those policies) so nothing is orphaned or hard-deleted.
+   *
+   * The user remains recoverable: restoring is a matter of clearing the
+   * shared deletedAt timestamp (see SoftDeleteService.restore).
+   */
   async delete(id: string): Promise<{ id: string; deletedAt: Date | null }> {
     await this.findById(id);
-    const deletedUser = await this.prisma.user.delete({
-      where: { id },
-    });
+
+    const deletedAt = new Date();
+
+    // Single transaction so the user and their related records are either
+    // all soft-deleted or none are. The soft-delete middleware limits each
+    // update to rows that are still active, preserving earlier deletions.
+    const [deletedUser] = await this.prisma.$transaction([
+      this.prisma.user.update({
+        where: { id },
+        data: { deletedAt },
+      }),
+      this.prisma.notification.updateMany({
+        where: { userId: id },
+        data: { deletedAt },
+      }),
+      this.prisma.notificationSetting.updateMany({
+        where: { userId: id },
+        data: { deletedAt },
+      }),
+      this.prisma.insurancePolicy.updateMany({
+        where: { userId: id },
+        data: { deletedAt },
+      }),
+      this.prisma.claim.updateMany({
+        where: { policy: { userId: id } },
+        data: { deletedAt },
+      }),
+    ]);
+
     return {
       id: deletedUser.id,
       deletedAt: deletedUser.deletedAt,


### PR DESCRIPTION
Closes #410

## What
Enforces soft-delete semantics across every model in the domain, removes the hard-delete bypass in `UserService`, and turns every remaining permanent deletion into an explicit, audited purge path.

## Why
`UserService.delete()` issued a raw `prisma.user.delete(...)`, and `SOFT_DELETE_MODELS` was missing `Notification`, `NotificationSetting`, `EmailOutbox`, `IdempotencyKey` and `IndexerLog`, so "delete" semantics were inconsistent across the domain and user rows could be destroyed, orphaning their policies, claims and notifications. While auditing all direct `prisma.*.delete(...)` call sites I also found the inverse bug: the middleware converted **every** delete to a soft delete, so `SoftDeleteService.hardDelete()`/`permanentlyDeleteExpired()` never actually purged anything, `restore()` could never reach a soft-deleted row, and the indexer's re-org rollback left soft-deleted rows holding unique `eventId`s that would block re-processing.

## Changes

**Middleware (`src/prisma.soft-delete.middleware.ts`)**
- Added the 5 missing models; `SOFT_DELETE_MODELS` now covers all 18 schema models (locked by a test against `Prisma.ModelName`).
- Hardened the `delete`/`deleteMany` path: conversions only touch rows that are still active, and a real delete now requires an explicit `hardDelete`/`_hardDelete` opt-out reserved for audited purge paths.
- Restores (`data.deletedAt = null`) can now reach soft-deleted rows — previously `SoftDeleteService.restore()` was silently unreachable because the update filter excluded the very rows it needed to recover.

**UserService (`src/user/user.service.ts`)**
- `delete()` now performs an explicit `update({ deletedAt })` inside a single transaction and cascades the *same* timestamp to the user's notifications, notification settings, insurance policies and the claims on those policies, so nothing is orphaned and the whole cascade is restorable as a unit.
- `findById` / `findByWallet` / `findPaginated` carry explicit `deletedAt: null` filters as defense in depth on top of the middleware.

**Audited purge paths**
- `SoftDeleteService.hardDelete/hardDeleteMany/permanentlyDeleteExpired` now genuinely bypass the middleware and write an `AuditLog` entry (action `DELETE`, entity, filter, reason) for every purge.
- Indexer re-org rollback (`ledger-tracker.service.ts`) purges rolled-back `ProcessedEvent` rows through `SoftDeleteService.hardDeleteMany` with an explicit reason — a soft delete here would keep the unique `eventId` and block events from being re-indexed after the rollback.

**IdempotencyInterceptor (`src/interceptors/idempotency.interceptor.ts`)**
- Expired keys are reset in place instead of delete + recreate: with `IdempotencyKey` soft-deleted, the old row would keep holding the unique `key` and the recreate would fail with P2002. This also fixes a pre-existing bug where retrying a request whose key was `FAILED` (but not expired) crashed on the unique constraint.

**Controllers / API surface**
- `NotificationController` rejects missing or soft-deleted users with 404 (`upsert` bypasses the middleware, so it previously leaked a deleted user's settings), and clears the soft-delete marker on settings for active users.
- `ResponseTransformInterceptor` strips `deletedAt` from API payloads so the internal marker never leaks; explicitly shaped bodies (like the delete acknowledgement) are untouched.

**Schema / migrations** — no changes needed: `deletedAt` + `@@index([deletedAt])` already exist on all listed models (added in #407); this PR closes the enforcement gap in code.

**Tests & docs**
- New suites: `prisma.soft-delete.middleware.spec.ts` (16 tests: model coverage, delete conversion, escape hatch, restore reachability) and `response.interceptor.spec.ts`.
- Extended `user.service.spec.ts` with cascade/transaction coverage; repaired `notification.controller.spec.ts` (missing DI providers) and `user.controller.spec.ts` (compile error) which failed before this PR.
- Updated the three SOFT_DELETE docs to list all 18 models.

## Acceptance criteria
- ✅ No service issues a hard `prisma.*.delete(...)` outside an explicit, audited purge path (`SoftDeleteService`, with `AuditLog` trail).
- ✅ All listed models honor soft-delete via the middleware (test-enforced against `Prisma.ModelName`).
- ✅ A soft-deleted user no longer appears in queries (middleware + explicit filters) but remains recoverable (`SoftDeleteService.restore`, shared cascade timestamp).

## Verification
- `npm run build` ✅ and `tsc --noEmit` ✅
- `npx jest`: 123 passing (vs 85 on `main`); the remaining failures are pre-existing on `main` and unrelated (verified by running the full suite on a clean `main` worktree — identical failure set minus the three suites this PR fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
