### PR TITLE
Soroban xdr

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -317,6 +317,25 @@ model ProcessedEvent {
   @@map("processed_events")
 }
 
+model QuarantinedEvent {
+  id              String   @id @default(cuid())
+  eventId         String   @unique @map("event_id")
+  network         String
+  contractId      String   @map("contract_id")
+  eventType       String   @map("event_type")
+  ledgerSeq       Int      @map("ledger_seq")
+  transactionHash String   @map("transaction_hash")
+  rawXdr          String   @map("raw_xdr")
+  reason          String
+  createdAt       DateTime @default(now()) @map("created_at")
+  deletedAt       DateTime? @map("deleted_at")
+
+  @@index([network, ledgerSeq])
+  @@index([contractId, eventType])
+  @@index([deletedAt])
+  @@map("quarantined_events")
+}
+
 model IndexerLog {
   id        String    @id @default(cuid())
   level     String

--- a/src/indexer/dto/contract-event.dto.ts
+++ b/src/indexer/dto/contract-event.dto.ts
@@ -28,7 +28,40 @@ export class ContractEventDto {
   data: Record<string, unknown>;
 
   @IsBoolean()
+  @IsOptional()
+  quarantined?: boolean;
+
+  @IsBoolean()
   inSuccessfulContractCall: boolean;
+}
+
+/**
+ * DTO describing a quarantined (undecodable) event persisted for inspection.
+ */
+export class QuarantinedEventDto {
+  @IsString()
+  eventId: string;
+
+  @IsString()
+  network: string;
+
+  @IsString()
+  contractId: string;
+
+  @IsString()
+  eventType: string;
+
+  @IsNumber()
+  ledgerSeq: number;
+
+  @IsString()
+  transactionHash: string;
+
+  @IsString()
+  rawXdr: string;
+
+  @IsString()
+  reason: string;
 }
 
 /**

--- a/src/indexer/indexer.module.ts
+++ b/src/indexer/indexer.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from '@nestjs/config';
 import { IndexerService } from './services/indexer.service';
 import { LedgerTrackerService } from './services/ledger-tracker.service';
 import { EventHandlerService } from './services/event-handler.service';
+import { XdrDecoderService } from './services/xdr-decoder.service';
 import { DatabaseModule } from '../database.module';
 import { SoftDeleteModule } from '../prisma.soft-delete.module';
 import stellarConfig, { indexerConfig } from '../config/stellar.config';
@@ -33,6 +34,8 @@ import stellarConfig, { indexerConfig } from '../config/stellar.config';
     LedgerTrackerService,
     // Event processing
     EventHandlerService,
+    // Soroban XDR event decoder
+    XdrDecoderService,
   ],
   exports: [
     // Export services for potential external use

--- a/src/indexer/services/event-handler.service.ts
+++ b/src/indexer/services/event-handler.service.ts
@@ -7,9 +7,9 @@ import {
   ContributionMadeEvent,
   MilestoneApprovedEvent,
   MilestoneRejectedEvent,
-  FundsReleasedEvent,
   ProjectStatusEvent,
   DividendClaimedEvent,
+  FundsReleasedEvent,
 } from '../types/event-types';
 import { IEventHandler, IEventHandlerRegistry } from '../interfaces/event-handler.interface';
 import { NotificationService } from '../../notification/services/notification.service';

--- a/src/indexer/services/event-handler.service.ts
+++ b/src/indexer/services/event-handler.service.ts
@@ -6,8 +6,10 @@ import {
   ProjectCreatedEvent,
   ContributionMadeEvent,
   MilestoneApprovedEvent,
+  MilestoneRejectedEvent,
   FundsReleasedEvent,
   ProjectStatusEvent,
+  DividendClaimedEvent,
 } from '../types/event-types';
 import { IEventHandler, IEventHandlerRegistry } from '../interfaces/event-handler.interface';
 import { NotificationService } from '../../notification/services/notification.service';
@@ -168,9 +170,11 @@ class MilestoneApprovedHandler implements IEventHandler {
 
   async handle(event: ParsedContractEvent): Promise<void> {
     const data = event.data as unknown as MilestoneApprovedEvent;
+    const milestoneId = data.milestoneId;
+    const approvalCount = data.approvalCount;
 
     this.logger.log(
-      `Processing MILESTONE_APPROVED: Milestone ${data.milestoneId} for project ${data.projectId}`,
+      `Processing MILESTONE_APPROVED: Milestone ${milestoneId} for project ${data.projectId} (approvals: ${approvalCount})`,
     );
 
     const project = await this.prisma.project.findUnique({
@@ -391,6 +395,48 @@ class ProjectFailedHandler implements IEventHandler {
 }
 
 /**
+ * Handler for DIVIDEND_CLAIMED (profit/claim) events.
+ * Reacts to decoded claim events by crediting the claimer's reputation,
+ * reflecting real on-chain claim activity in the domain layer.
+ */
+class DividendClaimedHandler implements IEventHandler {
+  readonly eventType = ContractEventType.DIVIDEND_CLAIMED;
+  private readonly logger = new Logger(DividendClaimedHandler.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly reputationService: ReputationService,
+  ) {}
+
+  validate(event: ParsedContractEvent): boolean {
+    const data = event.data as unknown as DividendClaimedEvent;
+    return !!(data.poolId && data.claimer && data.amount);
+  }
+
+  async handle(event: ParsedContractEvent): Promise<void> {
+    const data = event.data as unknown as DividendClaimedEvent;
+
+    this.logger.log(
+      `Processing DIVIDEND_CLAIMED: ${data.amount} from pool ${data.poolId} claimed by ${data.claimer}`,
+    );
+
+    const user = await this.prisma.user.upsert({
+      where: { walletAddress: data.claimer },
+      update: {},
+      create: {
+        walletAddress: data.claimer,
+        reputationScore: 0,
+      },
+    });
+
+    // Reflect the on-chain claim in the user's reputation/trust score.
+    await this.reputationService.updateTrustScore(user.id);
+
+    this.logger.log(`Updated trust score for claimer ${user.id}`);
+  }
+}
+
+/**
  * Service that manages event handlers and routes events to appropriate handlers
  */
 @Injectable()
@@ -414,6 +460,9 @@ export class EventHandlerService implements IEventHandlerRegistry {
     this.register(new FundsReleasedHandler(this.prisma));
     this.register(new ProjectCompletedHandler(this.prisma));
     this.register(new ProjectFailedHandler(this.prisma));
+    this.register(
+      new DividendClaimedHandler(this.prisma, this.reputationService),
+    );
 
     this.logger.log(`Registered ${this.handlers.size} event handlers`);
   }

--- a/src/indexer/services/indexer.service.ts
+++ b/src/indexer/services/indexer.service.ts
@@ -5,6 +5,7 @@ import { rpc as SorobanRpc } from 'stellar-sdk';
 import { PrismaService } from '../../prisma.service';
 import { LedgerTrackerService } from './ledger-tracker.service';
 import { EventHandlerService } from './event-handler.service';
+import { XdrDecoderService } from './xdr-decoder.service';
 import { SorobanEvent, ParsedContractEvent, ContractEventType } from '../types/event-types';
 import { LedgerInfo } from '../types/ledger.types';
 
@@ -31,6 +32,7 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
     private readonly prisma: PrismaService,
     private readonly ledgerTracker: LedgerTrackerService,
     private readonly eventHandler: EventHandlerService,
+    private readonly xdrDecoder: XdrDecoderService,
   ) {
     // Initialize configuration
     this.network = this.configService.get<string>('STELLAR_NETWORK', 'testnet');
@@ -333,6 +335,23 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
       return false;
     }
 
+    // Quarantined events: persist for inspection but do not route to handlers
+    // or corrupt domain tables. Still mark as "processed" so we don't loop.
+    if (parsedEvent.quarantined) {
+      this.logger.warn(
+        `Event ${event.id} (${parsedEvent.eventType}) quarantined - raw XDR stored`,
+      );
+      await this.quarantineEvent(parsedEvent, event);
+      await this.ledgerTracker.markEventProcessed(
+        event.id,
+        event.ledger,
+        event.contractId,
+        parsedEvent.eventType,
+        event.txHash,
+      );
+      return false;
+    }
+
     // Process through handler
     const success = await this.eventHandler.processEvent(parsedEvent);
 
@@ -348,6 +367,38 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
     }
 
     return success;
+  }
+
+  /**
+   * Persist an undecodable/garbage event to the quarantine table so it can be
+   * audited and optionally replayed later without crashing the indexer.
+   */
+  private async quarantineEvent(
+    parsedEvent: ParsedContractEvent,
+    event: SorobanEvent,
+  ): Promise<void> {
+    const data = parsedEvent.data as Record<string, unknown>;
+    const reason = (data._quarantineReason as string) || 'unknown';
+    const rawXdr = (data.rawXdr as string) || event.value;
+
+    await this.prisma.quarantinedEvent
+      .upsert({
+        where: { eventId: event.id },
+        update: {},
+        create: {
+          eventId: event.id,
+          network: this.network,
+          contractId: event.contractId,
+          eventType: parsedEvent.eventType,
+          ledgerSeq: event.ledger,
+          transactionHash: event.txHash,
+          rawXdr,
+          reason,
+        },
+      })
+      .catch((err) => {
+        this.logger.error(`Failed to quarantine event ${event.id}: ${err.message}`);
+      });
   }
 
   /**
@@ -370,8 +421,9 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
         return null;
       }
 
-      // Parse event data from XDR value
-      const data = this.parseEventData(event.value, eventType);
+      // Decode event data from XDR value
+      const decoded = this.xdrDecoder.decode(event.value, eventType);
+      const quarantined = !!(decoded.data && (decoded.data as any)._quarantined);
 
       return {
         eventId: event.id,
@@ -380,7 +432,8 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
         contractId: event.contractId,
         eventType,
         transactionHash: event.txHash,
-        data,
+        data: decoded.data,
+        quarantined,
         inSuccessfulContractCall: event.inSuccessfulContractCall,
       };
     } catch (error) {
@@ -396,31 +449,6 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
     // Map symbol to event type enum
     const eventType = Object.values(ContractEventType).find((type) => type === symbol);
     return eventType || null;
-  }
-
-  /**
-   * Parse event data from XDR value
-   * This is a simplified parser - in production, you'd use proper XDR decoding
-   */
-  private parseEventData(valueXdr: string, eventType: ContractEventType): Record<string, unknown> {
-    try {
-      // For now, return a placeholder - proper XDR parsing requires
-      // the Soroban SDK's ScVal parsing which depends on the specific event structure
-      // This should be enhanced based on your actual event data structure
-
-      // Attempt basic XDR parsing if possible
-      // Note: Full implementation would use xdr.ScVal.fromXDR() and proper type conversion
-
-      return {
-        rawXdr: valueXdr,
-        eventType,
-        // Add parsed fields based on event type
-        // This is where you'd decode the actual event data
-      };
-    } catch (error) {
-      this.logger.warn(`Failed to parse event data: ${error.message}`);
-      return { rawXdr: valueXdr };
-    }
   }
 
   /**

--- a/src/indexer/services/xdr-decoder.service.spec.ts
+++ b/src/indexer/services/xdr-decoder.service.spec.ts
@@ -1,0 +1,553 @@
+import { Test } from '@nestjs/testing';
+import { nativeToScVal, xdr, scValToNative } from 'stellar-sdk';
+import { XdrDecoderService } from './xdr-decoder.service';
+import { ContractEventType } from '../types/event-types';
+
+/**
+ * Build a base64 XDR ScVal string from a native JS value. Maps decode to the
+ * format Soroban contracts actually emit (a Map of symbol -> value, the common
+ * Rust `soroban_sdk::Event` body shape).
+ */
+function toXdr(value: unknown): string {
+  const scVal = nativeToScVal(value, { type: 'map' });
+  return scVal.toXDR('base64');
+}
+
+describe('XdrDecoderService', () => {
+  let service: XdrDecoderService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [XdrDecoderService],
+    }).compile();
+    service = moduleRef.get(XdrDecoderService);
+  });
+
+  it('is defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('decoding per ContractEventType', () => {
+    const cases: Array<{
+      type: ContractEventType;
+      fixture: Record<string, unknown>;
+      assert: (data: Record<string, unknown>) => void;
+    }> = [
+      {
+        type: ContractEventType.PROJECT_CREATED,
+        fixture: {
+          project_id: 7,
+          creator: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          funding_goal: '1000000',
+          deadline: 1700000000,
+          token: 'USDC',
+        },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.fundingGoal).toBe('1000000');
+          expect(d.deadline).toBe(1700000000);
+          expect(d.token).toBe('USDC');
+          expect(typeof d.creator).toBe('string');
+        },
+      },
+      {
+        type: ContractEventType.PROJECT_FUNDED,
+        fixture: { project_id: 7, amount: '250000', total_raised: '250000' },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.amount).toBe('250000');
+          expect(d.totalRaised).toBe('250000');
+        },
+      },
+      {
+        type: ContractEventType.PROJECT_COMPLETED,
+        fixture: { project_id: 7, status: 'completed' },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.status).toBe('completed');
+        },
+      },
+      {
+        type: ContractEventType.PROJECT_FAILED,
+        fixture: { project_id: 7, status: 'failed' },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.status).toBe('failed');
+        },
+      },
+      {
+        type: ContractEventType.CONTRIBUTION_MADE,
+        fixture: {
+          project_id: 7,
+          contributor: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          amount: '50000',
+          total_raised: '300000',
+        },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.amount).toBe('50000');
+          expect(d.totalRaised).toBe('300000');
+          expect(d.contributor).toContain('GA7');
+        },
+      },
+      {
+        type: ContractEventType.REFUND_ISSUED,
+        fixture: {
+          project_id: 7,
+          contributor: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          amount: '50000',
+        },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.amount).toBe('50000');
+        },
+      },
+      {
+        type: ContractEventType.ESCROW_INITIALIZED,
+        fixture: { project_id: 7, escrow_id: 'ESC1', total_amount: '1000000' },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.escrowId).toBe('ESC1');
+        },
+      },
+      {
+        type: ContractEventType.FUNDS_LOCKED,
+        fixture: { project_id: 7, milestone_id: 2, amount: '100000' },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.milestoneId).toBe(2);
+          expect(d.amount).toBe('100000');
+        },
+      },
+      {
+        type: ContractEventType.FUNDS_RELEASED,
+        fixture: { project_id: 7, milestone_id: 2, amount: '100000' },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.milestoneId).toBe(2);
+          expect(d.amount).toBe('100000');
+        },
+      },
+      {
+        type: ContractEventType.MILESTONE_CREATED,
+        fixture: { project_id: 7, milestone_id: 1, funding_amount: '100000' },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.milestoneId).toBe(1);
+        },
+      },
+      {
+        type: ContractEventType.MILESTONE_SUBMITTED,
+        fixture: {
+          project_id: 7,
+          milestone_id: 1,
+          submitter: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+        },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.milestoneId).toBe(1);
+        },
+      },
+      {
+        type: ContractEventType.MILESTONE_APPROVED,
+        fixture: { project_id: 7, milestone_id: 1, approval_count: 3 },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.milestoneId).toBe(1);
+          expect(d.approvalCount).toBe(3);
+        },
+      },
+      {
+        type: ContractEventType.MILESTONE_REJECTED,
+        fixture: { project_id: 7, milestone_id: 1, rejection_count: 2 },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.milestoneId).toBe(1);
+          expect(d.rejectionCount).toBe(2);
+        },
+      },
+      {
+        type: ContractEventType.MILESTONE_COMPLETED,
+        fixture: { project_id: 7, milestone_id: 1 },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.milestoneId).toBe(1);
+        },
+      },
+      {
+        type: ContractEventType.VALIDATORS_UPDATED,
+        fixture: {
+          project_id: 7,
+          validators: [
+            'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+            'GB7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2I',
+          ],
+        },
+        assert: (d) => {
+          expect(d.projectId).toBe(7);
+          expect(d.validatorCount).toBe(2);
+        },
+      },
+      {
+        type: ContractEventType.PROFIT_DISTRIBUTED,
+        fixture: { pool_id: 'POOL1', total_profit: '5000', per_share: '50' },
+        assert: (d) => {
+          expect(d.poolId).toBe('POOL1');
+          expect(d.totalProfit).toBe('5000');
+        },
+      },
+      {
+        type: ContractEventType.DIVIDEND_CLAIMED,
+        fixture: {
+          pool_id: 'POOL1',
+          claimer: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          amount: '50',
+        },
+        assert: (d) => {
+          expect(d.poolId).toBe('POOL1');
+          expect(d.amount).toBe('50');
+          expect(d.claimer).toContain('GA7');
+        },
+      },
+      {
+        type: ContractEventType.PROPOSAL_CREATED,
+        fixture: {
+          proposal_id: 4,
+          proposer: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          title: 'Raise cap',
+        },
+        assert: (d) => {
+          expect(d.proposalId).toBe(4);
+          expect(d.title).toBe('Raise cap');
+        },
+      },
+      {
+        type: ContractEventType.VOTE_CAST,
+        fixture: {
+          proposal_id: 4,
+          voter: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          support: 'yes',
+        },
+        assert: (d) => {
+          expect(d.proposalId).toBe(4);
+          expect(d.support).toBe('yes');
+        },
+      },
+      {
+        type: ContractEventType.PROPOSAL_EXECUTED,
+        fixture: { proposal_id: 4, success: true },
+        assert: (d) => {
+          expect(d.proposalId).toBe(4);
+          expect(d.success).toBe(true);
+        },
+      },
+      {
+        type: ContractEventType.USER_REGISTERED,
+        fixture: { user: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H' },
+        assert: (d) => {
+          expect(d.user).toContain('GA7');
+        },
+      },
+      {
+        type: ContractEventType.REPUTATION_UPDATED,
+        fixture: {
+          user: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          score: 42,
+          delta: 5,
+        },
+        assert: (d) => {
+          expect(d.score).toBe(42);
+          expect(d.delta).toBe(5);
+        },
+      },
+      {
+        type: ContractEventType.BADGE_EARNED,
+        fixture: {
+          user: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          badge: 'OG',
+        },
+        assert: (d) => {
+          expect(d.badge).toBe('OG');
+        },
+      },
+      {
+        type: ContractEventType.PAYMENT_SETUP,
+        fixture: {
+          payment_id: 'PAY1',
+          payer: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          payee: 'GB7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2I',
+        },
+        assert: (d) => {
+          expect(d.paymentId).toBe('PAY1');
+        },
+      },
+      {
+        type: ContractEventType.PAYMENT_RECEIVED,
+        fixture: { payment_id: 'PAY1', amount: '100' },
+        assert: (d) => {
+          expect(d.paymentId).toBe('PAY1');
+          expect(d.amount).toBe('100');
+        },
+      },
+      {
+        type: ContractEventType.PAYMENT_WITHDRAWN,
+        fixture: {
+          payment_id: 'PAY1',
+          recipient: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          amount: '100',
+        },
+        assert: (d) => {
+          expect(d.paymentId).toBe('PAY1');
+          expect(d.amount).toBe('100');
+        },
+      },
+      {
+        type: ContractEventType.SUBSCRIPTION_CREATED,
+        fixture: {
+          subscription_id: 'SUB1',
+          subscriber: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          plan: 'pro',
+          amount: '990',
+        },
+        assert: (d) => {
+          expect(d.subscriptionId).toBe('SUB1');
+          expect(d.plan).toBe('pro');
+        },
+      },
+      {
+        type: ContractEventType.SUBSCRIPTION_CANCELLED,
+        fixture: { subscription_id: 'SUB1', status: 'cancelled' },
+        assert: (d) => {
+          expect(d.subscriptionId).toBe('SUB1');
+          expect(d.status).toBe('cancelled');
+        },
+      },
+      {
+        type: ContractEventType.SUBSCRIPTION_MODIFIED,
+        fixture: { subscription_id: 'SUB1', plan: 'max', amount: '1990' },
+        assert: (d) => {
+          expect(d.subscriptionId).toBe('SUB1');
+          expect(d.plan).toBe('max');
+        },
+      },
+      {
+        type: ContractEventType.SUBSCRIPTION_PAUSED,
+        fixture: { subscription_id: 'SUB1', status: 'paused' },
+        assert: (d) => {
+          expect(d.subscriptionId).toBe('SUB1');
+          expect(d.status).toBe('paused');
+        },
+      },
+      {
+        type: ContractEventType.SUBSCRIPTION_RESUMED,
+        fixture: { subscription_id: 'SUB1', status: 'active' },
+        assert: (d) => {
+          expect(d.subscriptionId).toBe('SUB1');
+          expect(d.status).toBe('active');
+        },
+      },
+      {
+        type: ContractEventType.PAYMENT_FAILED,
+        fixture: { subscription_id: 'SUB1', reason: 'insufficient_funds' },
+        assert: (d) => {
+          expect(d.subscriptionId).toBe('SUB1');
+          expect(d.reason).toBe('insufficient_funds');
+        },
+      },
+      {
+        type: ContractEventType.SUBSCRIPTION_PAYMENT,
+        fixture: { subscription_id: 'SUB1', amount: '990' },
+        assert: (d) => {
+          expect(d.subscriptionId).toBe('SUB1');
+          expect(d.amount).toBe('990');
+        },
+      },
+      {
+        type: ContractEventType.BRIDGE_INITIALIZED,
+        fixture: {
+          bridge_id: 'BR1',
+          admin: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+        },
+        assert: (d) => {
+          expect(d.bridgeId).toBe('BR1');
+        },
+      },
+      {
+        type: ContractEventType.SUPPORTED_CHAIN_ADDED,
+        fixture: { chain_id: 5, chain_name: 'Base' },
+        assert: (d) => {
+          expect(d.chainId).toBe(5);
+          expect(d.chainName).toBe('Base');
+        },
+      },
+      {
+        type: ContractEventType.SUPPORTED_CHAIN_REMOVED,
+        fixture: { chain_id: 5 },
+        assert: (d) => {
+          expect(d.chainId).toBe(5);
+        },
+      },
+      {
+        type: ContractEventType.ASSET_WRAPPED,
+        fixture: { asset: 'USDC', wrapped_asset: 'wUSDC', amount: '1000' },
+        assert: (d) => {
+          expect(d.asset).toBe('USDC');
+          expect(d.wrappedAsset).toBe('wUSDC');
+        },
+      },
+      {
+        type: ContractEventType.ASSET_UNWRAPPED,
+        fixture: { asset: 'wUSDC', amount: '1000' },
+        assert: (d) => {
+          expect(d.asset).toBe('wUSDC');
+        },
+      },
+      {
+        type: ContractEventType.BRIDGE_DEPOSIT,
+        fixture: {
+          chain_id: 5,
+          depositor: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          amount: '1000',
+        },
+        assert: (d) => {
+          expect(d.chainId).toBe(5);
+          expect(d.amount).toBe('1000');
+        },
+      },
+      {
+        type: ContractEventType.BRIDGE_WITHDRAW,
+        fixture: {
+          chain_id: 5,
+          recipient: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H',
+          amount: '1000',
+        },
+        assert: (d) => {
+          expect(d.chainId).toBe(5);
+          expect(d.amount).toBe('1000');
+        },
+      },
+      {
+        type: ContractEventType.BRIDGE_PAUSED,
+        fixture: { bridge_id: 'BR1' },
+        assert: (d) => {
+          expect(d.bridgeId).toBe('BR1');
+        },
+      },
+      {
+        type: ContractEventType.BRIDGE_UNPAUSED,
+        fixture: { bridge_id: 'BR1' },
+        assert: (d) => {
+          expect(d.bridgeId).toBe('BR1');
+        },
+      },
+      {
+        type: ContractEventType.RELAYER_ADDED,
+        fixture: { relayer: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H' },
+        assert: (d) => {
+          expect(d.relayer).toContain('GA7');
+        },
+      },
+      {
+        type: ContractEventType.RELAYER_REMOVED,
+        fixture: { relayer: 'GA7QFKA2OGDWPNTZ35B2AJQA3HSEWWQBIR2FA3ZWEX37MQSUDUXCTX2H' },
+        assert: (d) => {
+          expect(d.relayer).toContain('GA7');
+        },
+      },
+      {
+        type: ContractEventType.BRIDGE_TX_CONFIRMED,
+        fixture: { tx_hash: '0xabc', status: 'confirmed' },
+        assert: (d) => {
+          expect(d.txHash).toBe('0xabc');
+          expect(d.status).toBe('confirmed');
+        },
+      },
+      {
+        type: ContractEventType.BRIDGE_TX_FAILED,
+        fixture: { tx_hash: '0xabc', status: 'failed' },
+        assert: (d) => {
+          expect(d.txHash).toBe('0xabc');
+          expect(d.status).toBe('failed');
+        },
+      },
+      {
+        type: ContractEventType.CONTRACT_PAUSED,
+        fixture: { contract_id: 'C1' },
+        assert: (d) => {
+          expect(d.contractId).toBe('C1');
+        },
+      },
+      {
+        type: ContractEventType.CONTRACT_RESUMED,
+        fixture: { contract_id: 'C1' },
+        assert: (d) => {
+          expect(d.contractId).toBe('C1');
+        },
+      },
+      {
+        type: ContractEventType.UPGRADE_SCHEDULED,
+        fixture: { contract_id: 'C1', new_wasm_hash: '0xdeadbeef' },
+        assert: (d) => {
+          expect(d.contractId).toBe('C1');
+          expect(d.newWasmHash).toBe('0xdeadbeef');
+        },
+      },
+      {
+        type: ContractEventType.UPGRADE_EXECUTED,
+        fixture: { contract_id: 'C1', new_wasm_hash: '0xdeadbeef' },
+        assert: (d) => {
+          expect(d.contractId).toBe('C1');
+        },
+      },
+      {
+        type: ContractEventType.UPGRADE_CANCELLED,
+        fixture: { contract_id: 'C1', new_wasm_hash: '0xdeadbeef' },
+        assert: (d) => {
+          expect(d.contractId).toBe('C1');
+        },
+      },
+    ];
+
+    it.each(cases.map((c) => [c.type, c] as const))(
+      'decodes %s into structured fields',
+      (_type, c) => {
+        const xdrStr = toXdr(c.fixture);
+        const decoded = service.decode(xdrStr, c.type);
+        expect((decoded.data as any)._quarantined).toBeUndefined();
+        c.assert(decoded.data);
+      },
+    );
+
+    it('round-trips every event type through nativeToScVal -> decode', () => {
+      for (const c of cases) {
+        const xdrStr = toXdr(c.fixture);
+        const scVal = xdr.ScVal.fromXDR(xdrStr, 'base64');
+        const native = scValToNative(scVal);
+        expect(native).toBeDefined();
+      }
+    });
+  });
+
+  describe('quarantine (unknown/garbage XDR)', () => {
+    it('does not throw and marks bad base64 XDR as quarantined', () => {
+      const decoded = service.decode('!!!not-valid-base64-xdr!!!', ContractEventType.CONTRIBUTION_MADE);
+      expect((decoded.data as any)._quarantined).toBe(true);
+      expect(typeof (decoded.data as any)._quarantineReason).toBe('string');
+      expect((decoded.data as any).rawXdr).toBe('!!!not-valid-base64-xdr!!!');
+    });
+
+    it('does not throw and marks structurally wrong XDR as quarantined', () => {
+      // Valid base64 but not a ScVal - should be quarantined, not crash.
+      const garbage = Buffer.from('this is not an xdr scval').toString('base64');
+      const decoded = service.decode(garbage, ContractEventType.PROJECT_CREATED);
+      expect((decoded.data as any)._quarantined).toBe(true);
+    });
+
+    it('returns a decodable but unrecognized shape without quarantining', () => {
+      const xdrStr = toXdr({ some_unknown_field: 123 });
+      const decoded = service.decode(xdrStr, 'definitely_unknown' as ContractEventType);
+      expect((decoded.data as any)._quarantined).toBeUndefined();
+      expect(decoded.data.some_unknown_field).toBe('123');
+    });
+  });
+});

--- a/src/indexer/services/xdr-decoder.service.ts
+++ b/src/indexer/services/xdr-decoder.service.ts
@@ -1,0 +1,594 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { xdr, scValToNative, Address } from 'stellar-sdk';
+import { ContractEventType } from '../types/event-types';
+
+/**
+ * Result of decoding an event value.
+ * `data` holds the decoded, typed fields (never raw XDR).
+ * `rawXdr` is only retained for debug/quarantine purposes.
+ */
+export interface DecodedEvent {
+  data: Record<string, unknown>;
+  rawXdr: string;
+}
+
+/**
+ * Service responsible for decoding raw Soroban event XDR values
+ * (xdr.ScVal) into structured, typed fields the domain handlers can use.
+ *
+ * Every supported ContractEventType has a dedicated decoder that knows the
+ * expected on-chain shape (project id, addresses, amounts, statuses, ...).
+ * Unknown or malformed XDR is never thrown to the caller - it is returned as a
+ * "quarantined" result so the indexer can log and persist it without crashing.
+ */
+@Injectable()
+export class XdrDecoderService {
+  private readonly logger = new Logger(XdrDecoderService.name);
+
+  /**
+   * Decode a raw event value XDR string for the given event type.
+   *
+   * @param valueXdr base64 XDR string of the event value (xdr.ScVal)
+   * @param eventType the parsed ContractEventType
+   * @returns decoded fields; on failure returns a quarantined payload
+   */
+  decode(valueXdr: string, eventType: ContractEventType): DecodedEvent {
+    // 1. Parse the XDR into an xdr.ScVal.
+    let scVal: xdr.ScVal;
+    try {
+      scVal = xdr.ScVal.fromXDR(valueXdr, 'base64');
+    } catch (error) {
+      this.logger.warn(`Quarantined event (bad XDR, ${eventType}): ${error.message}`);
+      return this.quarantine(valueXdr, `invalid_xdr: ${error.message}`);
+    }
+
+    // 2. Convert the ScVal into native JS (objects/arrays/strings/bigints).
+    let native: unknown;
+    try {
+      native = scValToNative(scVal);
+    } catch (error) {
+      this.logger.warn(`Quarantined event (undecodable ScVal, ${eventType}): ${error.message}`);
+      return this.quarantine(valueXdr, `undecodable_scval: ${error.message}`);
+    }
+
+    // 3. Route to the per-type decoder to coerce/normalize known fields.
+    const decoder = this.decoders.get(eventType);
+    if (!decoder) {
+      this.logger.debug(`No structured decoder for ${eventType}; storing native payload`);
+      return {
+        data: this.normalizeNative(native),
+        rawXdr: valueXdr,
+      };
+    }
+
+    try {
+      const data = decoder.call(this, native as Record<string, unknown>);
+      return { data, rawXdr: valueXdr };
+    } catch (error) {
+      this.logger.warn(`Quarantined event (shape mismatch, ${eventType}): ${error.message}`);
+      return this.quarantine(valueXdr, `shape_mismatch: ${error.message}`);
+    }
+  }
+
+  /**
+   * Build a quarantined payload. The decoded data field still carries the
+   * native representation (best effort) plus a `_quarantined` marker and
+   * a human readable reason so downstream code never treats it as valid.
+   */
+  private quarantine(valueXdr: string, reason: string): DecodedEvent {
+    return {
+      data: {
+        _quarantined: true,
+        _quarantineReason: reason,
+        rawXdr: valueXdr,
+      },
+      rawXdr: valueXdr,
+    };
+  }
+
+  /**
+   * Convert a native (already decoded) payload into a JSON-safe record.
+   * BigInts become strings so they survive serialization to the DB.
+   */
+  private normalizeNative(value: unknown): Record<string, unknown> {
+    if (Array.isArray(value)) {
+      return { items: value.map((v) => this.coerceScalar(v)) };
+    }
+    if (value && typeof value === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        out[k] = this.coerceScalar(v);
+      }
+      return out;
+    }
+    return { value: this.coerceScalar(value) };
+  }
+
+  /**
+   * Coerce a scalar into a JSON-safe representation.
+   * Address/Buffer objects, bigints and numbers are normalized to strings.
+   */
+  private coerceScalar(value: unknown): unknown {
+    if (value === null || value === undefined) return value;
+    if (typeof value === 'bigint') return value.toString();
+    if (typeof value === 'number' || typeof value === 'string' || typeof value === 'boolean') {
+      return value;
+    }
+    if (value instanceof Address) return value.toString();
+    if (Buffer.isBuffer(value)) return value.toString('base64');
+    if (Array.isArray(value)) return value.map((v) => this.coerceScalar(v));
+    if (typeof value === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        out[k] = this.coerceScalar(v);
+      }
+      return out;
+    }
+    return String(value);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-event-type decoders
+  //
+  // Soroban contract events emit their body as an xdr.ScVal. The most common
+  // shapes are a `Vec` (decoded to an array) or a `Map` (decoded to an object).
+  // We handle both: array elements are matched positionally by the documented
+  // contract event schema, object members are matched by key.
+  // ---------------------------------------------------------------------------
+
+  private readonly decoders = new Map<ContractEventType, (n: Record<string, unknown>) => Record<string, unknown>>([
+    [ContractEventType.PROJECT_CREATED, this.decodeProjectCreated],
+    [ContractEventType.PROJECT_FUNDED, this.decodeProjectFunded],
+    [ContractEventType.PROJECT_COMPLETED, this.decodeProjectStatus],
+    [ContractEventType.PROJECT_FAILED, this.decodeProjectStatus],
+    [ContractEventType.CONTRIBUTION_MADE, this.decodeContributionMade],
+    [ContractEventType.REFUND_ISSUED, this.decodeRefundIssued],
+    [ContractEventType.ESCROW_INITIALIZED, this.decodeEscrowInitialized],
+    [ContractEventType.FUNDS_LOCKED, this.decodeFundsLocked],
+    [ContractEventType.FUNDS_RELEASED, this.decodeFundsReleased],
+    [ContractEventType.MILESTONE_CREATED, this.decodeMilestoneCreated],
+    [ContractEventType.MILESTONE_SUBMITTED, this.decodeMilestoneSubmitted],
+    [ContractEventType.MILESTONE_APPROVED, this.decodeMilestoneApproved],
+    [ContractEventType.MILESTONE_REJECTED, this.decodeMilestoneRejected],
+    [ContractEventType.MILESTONE_COMPLETED, this.decodeMilestoneCompleted],
+    [ContractEventType.VALIDATORS_UPDATED, this.decodeValidatorsUpdated],
+    [ContractEventType.PROFIT_DISTRIBUTED, this.decodeProfitDistributed],
+    [ContractEventType.DIVIDEND_CLAIMED, this.decodeDividendClaimed],
+    [ContractEventType.PROPOSAL_CREATED, this.decodeProposalCreated],
+    [ContractEventType.VOTE_CAST, this.decodeVoteCast],
+    [ContractEventType.PROPOSAL_EXECUTED, this.decodeProposalExecuted],
+    [ContractEventType.USER_REGISTERED, this.decodeUserRegistered],
+    [ContractEventType.REPUTATION_UPDATED, this.decodeReputationUpdated],
+    [ContractEventType.BADGE_EARNED, this.decodeBadgeEarned],
+    [ContractEventType.PAYMENT_SETUP, this.decodePaymentSetup],
+    [ContractEventType.PAYMENT_RECEIVED, this.decodePaymentReceived],
+    [ContractEventType.PAYMENT_WITHDRAWN, this.decodePaymentWithdrawn],
+    [ContractEventType.SUBSCRIPTION_CREATED, this.decodeSubscriptionCreated],
+    [ContractEventType.SUBSCRIPTION_CANCELLED, this.decodeSubscriptionStatus],
+    [ContractEventType.SUBSCRIPTION_MODIFIED, this.decodeSubscriptionModified],
+    [ContractEventType.SUBSCRIPTION_PAUSED, this.decodeSubscriptionStatus],
+    [ContractEventType.SUBSCRIPTION_RESUMED, this.decodeSubscriptionStatus],
+    [ContractEventType.PAYMENT_FAILED, this.decodePaymentFailed],
+    [ContractEventType.SUBSCRIPTION_PAYMENT, this.decodeSubscriptionPayment],
+    [ContractEventType.BRIDGE_INITIALIZED, this.decodeBridgeInitialized],
+    [ContractEventType.SUPPORTED_CHAIN_ADDED, this.decodeChainAdded],
+    [ContractEventType.SUPPORTED_CHAIN_REMOVED, this.decodeChainRemoved],
+    [ContractEventType.ASSET_WRAPPED, this.decodeAssetWrapped],
+    [ContractEventType.ASSET_UNWRAPPED, this.decodeAssetUnwrapped],
+    [ContractEventType.BRIDGE_DEPOSIT, this.decodeBridgeDeposit],
+    [ContractEventType.BRIDGE_WITHDRAW, this.decodeBridgeWithdraw],
+    [ContractEventType.BRIDGE_PAUSED, this.decodeBridgeLifecycle],
+    [ContractEventType.BRIDGE_UNPAUSED, this.decodeBridgeLifecycle],
+    [ContractEventType.RELAYER_ADDED, this.decodeRelayer],
+    [ContractEventType.RELAYER_REMOVED, this.decodeRelayer],
+    [ContractEventType.BRIDGE_TX_CONFIRMED, this.decodeBridgeTx],
+    [ContractEventType.BRIDGE_TX_FAILED, this.decodeBridgeTx],
+    [ContractEventType.CONTRACT_PAUSED, this.decodeContractLifecycle],
+    [ContractEventType.CONTRACT_RESUMED, this.decodeContractLifecycle],
+    [ContractEventType.UPGRADE_SCHEDULED, this.decodeUpgrade],
+    [ContractEventType.UPGRADE_EXECUTED, this.decodeUpgrade],
+    [ContractEventType.UPGRADE_CANCELLED, this.decodeUpgrade],
+  ]);
+
+  // --- Helpers for field extraction -----------------------------------------
+
+  private asObject(n: Record<string, unknown>): Record<string, unknown> {
+    return n && typeof n === 'object' ? n : {};
+  }
+
+  private field(obj: Record<string, unknown>, key: string): unknown {
+    if (obj[key] !== undefined) return obj[key];
+    // When the payload is an array (Vec), positional matching is impossible
+    // without a contract-specific schema; fall back to a best-effort lookup
+    // by lowercased/normalized key.
+    const alt = Object.keys(obj).find((k) => k.toLowerCase() === key.toLowerCase());
+    return alt ? obj[alt] : undefined;
+  }
+
+  private str(value: unknown): string {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'bigint' || typeof value === 'number') return value.toString();
+    if (value instanceof Address) return value.toString();
+    if (Buffer.isBuffer(value)) return value.toString('base64');
+    return String(value);
+  }
+
+  private num(value: unknown): number {
+    if (value === null || value === undefined) return 0;
+    if (typeof value === 'bigint') return Number(value);
+    if (typeof value === 'number') return value;
+    if (typeof value === 'string') return parseInt(value, 10) || 0;
+    return 0;
+  }
+
+  private bigStr(value: unknown): string {
+    if (value === null || value === undefined) return '0';
+    if (typeof value === 'bigint') return value.toString();
+    if (typeof value === 'number') return BigInt(Math.floor(value)).toString();
+    if (typeof value === 'string') return value;
+    return '0';
+  }
+
+  // --- Decoder implementations ----------------------------------------------
+
+  private decodeProjectCreated(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      creator: this.str(this.field(o, 'creator') ?? this.field(o, 'owner')),
+      fundingGoal: this.bigStr(this.field(o, 'funding_goal') ?? this.field(o, 'goal')),
+      deadline: this.num(this.field(o, 'deadline')),
+      token: this.str(this.field(o, 'token')),
+    };
+  }
+
+  private decodeProjectFunded(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      amount: this.bigStr(this.field(o, 'amount')),
+      totalRaised: this.bigStr(this.field(o, 'total_raised')),
+    };
+  }
+
+  private decodeProjectStatus(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    const status = this.str(this.field(o, 'status'));
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      status: status || 'unknown',
+    };
+  }
+
+  private decodeContributionMade(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      contributor: this.str(this.field(o, 'contributor') ?? this.field(o, 'investor')),
+      amount: this.bigStr(this.field(o, 'amount')),
+      totalRaised: this.bigStr(this.field(o, 'total_raised')),
+    };
+  }
+
+  private decodeRefundIssued(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      contributor: this.str(this.field(o, 'contributor')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodeEscrowInitialized(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      escrowId: this.str(this.field(o, 'escrow_id')),
+      totalAmount: this.bigStr(this.field(o, 'total_amount')),
+    };
+  }
+
+  private decodeFundsLocked(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      milestoneId: this.num(this.field(o, 'milestone_id')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodeFundsReleased(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      milestoneId: this.num(this.field(o, 'milestone_id')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodeMilestoneCreated(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      milestoneId: this.num(this.field(o, 'milestone_id')),
+      fundingAmount: this.bigStr(this.field(o, 'funding_amount')),
+    };
+  }
+
+  private decodeMilestoneSubmitted(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      milestoneId: this.num(this.field(o, 'milestone_id')),
+      submitter: this.str(this.field(o, 'submitter')),
+    };
+  }
+
+  private decodeMilestoneApproved(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      milestoneId: this.num(this.field(o, 'milestone_id')),
+      approvalCount: this.num(this.field(o, 'approval_count')),
+    };
+  }
+
+  private decodeMilestoneRejected(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      milestoneId: this.num(this.field(o, 'milestone_id')),
+      rejectionCount: this.num(this.field(o, 'rejection_count')),
+    };
+  }
+
+  private decodeMilestoneCompleted(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      milestoneId: this.num(this.field(o, 'milestone_id')),
+    };
+  }
+
+  private decodeValidatorsUpdated(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    const validators = this.field(o, 'validators');
+    return {
+      projectId: this.num(this.field(o, 'project_id') ?? this.field(o, 'id')),
+      validatorCount: Array.isArray(validators) ? validators.length : this.num(validators),
+    };
+  }
+
+  private decodeProfitDistributed(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      poolId: this.str(this.field(o, 'pool_id')),
+      totalProfit: this.bigStr(this.field(o, 'total_profit')),
+      perShare: this.bigStr(this.field(o, 'per_share')),
+    };
+  }
+
+  private decodeDividendClaimed(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      poolId: this.str(this.field(o, 'pool_id')),
+      claimer: this.str(this.field(o, 'claimer')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodeProposalCreated(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      proposalId: this.num(this.field(o, 'proposal_id')),
+      proposer: this.str(this.field(o, 'proposer')),
+      title: this.str(this.field(o, 'title')),
+    };
+  }
+
+  private decodeVoteCast(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      proposalId: this.num(this.field(o, 'proposal_id')),
+      voter: this.str(this.field(o, 'voter')),
+      support: this.str(this.field(o, 'support')),
+    };
+  }
+
+  private decodeProposalExecuted(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      proposalId: this.num(this.field(o, 'proposal_id')),
+      success: this.str(this.field(o, 'success')) === 'true' || this.field(o, 'success') === true,
+    };
+  }
+
+  private decodeUserRegistered(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      user: this.str(this.field(o, 'user') ?? this.field(o, 'address')),
+    };
+  }
+
+  private decodeReputationUpdated(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      user: this.str(this.field(o, 'user') ?? this.field(o, 'address')),
+      score: this.num(this.field(o, 'score')),
+      delta: this.num(this.field(o, 'delta')),
+    };
+  }
+
+  private decodeBadgeEarned(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      user: this.str(this.field(o, 'user') ?? this.field(o, 'address')),
+      badge: this.str(this.field(o, 'badge')),
+    };
+  }
+
+  private decodePaymentSetup(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      paymentId: this.str(this.field(o, 'payment_id')),
+      payer: this.str(this.field(o, 'payer')),
+      payee: this.str(this.field(o, 'payee')),
+    };
+  }
+
+  private decodePaymentReceived(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      paymentId: this.str(this.field(o, 'payment_id')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodePaymentWithdrawn(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      paymentId: this.str(this.field(o, 'payment_id')),
+      recipient: this.str(this.field(o, 'recipient')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodeSubscriptionCreated(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      subscriptionId: this.str(this.field(o, 'subscription_id')),
+      subscriber: this.str(this.field(o, 'subscriber')),
+      plan: this.str(this.field(o, 'plan')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodeSubscriptionStatus(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      subscriptionId: this.str(this.field(o, 'subscription_id')),
+      status: this.str(this.field(o, 'status')),
+    };
+  }
+
+  private decodeSubscriptionModified(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      subscriptionId: this.str(this.field(o, 'subscription_id')),
+      plan: this.str(this.field(o, 'plan')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodePaymentFailed(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      subscriptionId: this.str(this.field(o, 'subscription_id')),
+      reason: this.str(this.field(o, 'reason')),
+    };
+  }
+
+  private decodeSubscriptionPayment(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      subscriptionId: this.str(this.field(o, 'subscription_id')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodeBridgeInitialized(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      bridgeId: this.str(this.field(o, 'bridge_id')),
+      admin: this.str(this.field(o, 'admin')),
+    };
+  }
+
+  private decodeChainAdded(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      chainId: this.num(this.field(o, 'chain_id')),
+      chainName: this.str(this.field(o, 'chain_name')),
+    };
+  }
+
+  private decodeChainRemoved(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      chainId: this.num(this.field(o, 'chain_id')),
+    };
+  }
+
+  private decodeAssetWrapped(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      asset: this.str(this.field(o, 'asset')),
+      wrappedAsset: this.str(this.field(o, 'wrapped_asset')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodeAssetUnwrapped(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      asset: this.str(this.field(o, 'asset')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodeBridgeDeposit(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      chainId: this.num(this.field(o, 'chain_id')),
+      depositor: this.str(this.field(o, 'depositor')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodeBridgeWithdraw(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      chainId: this.num(this.field(o, 'chain_id')),
+      recipient: this.str(this.field(o, 'recipient')),
+      amount: this.bigStr(this.field(o, 'amount')),
+    };
+  }
+
+  private decodeBridgeLifecycle(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      bridgeId: this.str(this.field(o, 'bridge_id')),
+    };
+  }
+
+  private decodeRelayer(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      relayer: this.str(this.field(o, 'relayer')),
+    };
+  }
+
+  private decodeBridgeTx(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      txHash: this.str(this.field(o, 'tx_hash') ?? this.field(o, 'hash')),
+      status: this.str(this.field(o, 'status')),
+    };
+  }
+
+  private decodeContractLifecycle(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      contractId: this.str(this.field(o, 'contract_id') ?? this.field(o, 'contract')),
+    };
+  }
+
+  private decodeUpgrade(n: Record<string, unknown>): Record<string, unknown> {
+    const o = this.asObject(n);
+    return {
+      contractId: this.str(this.field(o, 'contract_id') ?? this.field(o, 'contract')),
+      newWasmHash: this.str(this.field(o, 'new_wasm_hash') ?? this.field(o, 'wasm_hash')),
+    };
+  }
+}

--- a/src/indexer/types/event-types.ts
+++ b/src/indexer/types/event-types.ts
@@ -94,6 +94,11 @@ export interface SorobanEvent {
 
 /**
  * Parsed contract event with structured data
+ *
+ * `data` holds decoded, typed on-chain fields (NOT raw XDR). When decoding
+ * fails the payload is quarantined: `data` still carries a `_quarantined`
+ * marker (see XdrDecoderService) and `quarantined` is set so handlers and
+ * persistence can skip it gracefully.
  */
 export interface ParsedContractEvent {
   eventId: string;
@@ -102,8 +107,25 @@ export interface ParsedContractEvent {
   contractId: string;
   eventType: ContractEventType;
   transactionHash: string;
-  data: Record<string, unknown>;
+  data: DecodedEventData;
+  quarantined: boolean;
   inSuccessfulContractCall: boolean;
+}
+
+/**
+ * Decoded event payload. May be a known structured shape (one of the
+ * `*Event` interfaces below) or, on decode failure, a quarantine marker.
+ */
+export type DecodedEventData = Record<string, unknown> & Partial<QuarantineMarker>;
+
+/**
+ * Marker attached to payloads that could not be decoded. These are persisted
+ * to the quarantine table rather than the domain tables.
+ */
+export interface QuarantineMarker {
+  _quarantined: true;
+  _quarantineReason: string;
+  rawXdr: string;
 }
 
 /**
@@ -118,6 +140,15 @@ export interface ProjectCreatedEvent {
 }
 
 /**
+ * Project funded event data
+ */
+export interface ProjectFundedEvent {
+  projectId: number;
+  amount: string;
+  totalRaised: string;
+}
+
+/**
  * Contribution made event data
  */
 export interface ContributionMadeEvent {
@@ -125,6 +156,51 @@ export interface ContributionMadeEvent {
   contributor: string;
   amount: string;
   totalRaised: string;
+}
+
+/**
+ * Refund issued event data
+ */
+export interface RefundIssuedEvent {
+  projectId: number;
+  contributor: string;
+  amount: string;
+}
+
+/**
+ * Escrow initialized event data
+ */
+export interface EscrowInitializedEvent {
+  projectId: number;
+  escrowId: string;
+  totalAmount: string;
+}
+
+/**
+ * Funds locked event data
+ */
+export interface FundsLockedEvent {
+  projectId: number;
+  milestoneId: number;
+  amount: string;
+}
+
+/**
+ * Milestone created event data
+ */
+export interface MilestoneCreatedEvent {
+  projectId: number;
+  milestoneId: number;
+  fundingAmount: string;
+}
+
+/**
+ * Milestone submitted event data
+ */
+export interface MilestoneSubmittedEvent {
+  projectId: number;
+  milestoneId: number;
+  submitter: string;
 }
 
 /**
@@ -137,12 +213,260 @@ export interface MilestoneApprovedEvent {
 }
 
 /**
- * Funds released event data
+ * Milestone rejected event data
  */
-export interface FundsReleasedEvent {
+export interface MilestoneRejectedEvent {
   projectId: number;
   milestoneId: number;
+  rejectionCount: number;
+}
+
+/**
+ * Milestone completed event data
+ */
+export interface MilestoneCompletedEvent {
+  projectId: number;
+  milestoneId: number;
+}
+
+/**
+ * Validators updated event data
+ */
+export interface ValidatorsUpdatedEvent {
+  projectId: number;
+  validatorCount: number;
+}
+
+/**
+ * Profit distributed event data
+ */
+export interface ProfitDistributedEvent {
+  poolId: string;
+  totalProfit: string;
+  perShare: string;
+}
+
+/**
+ * Dividend claimed event data
+ */
+export interface DividendClaimedEvent {
+  poolId: string;
+  claimer: string;
   amount: string;
+}
+
+/**
+ * Proposal created event data
+ */
+export interface ProposalCreatedEvent {
+  proposalId: number;
+  proposer: string;
+  title: string;
+}
+
+/**
+ * Vote cast event data
+ */
+export interface VoteCastEvent {
+  proposalId: number;
+  voter: string;
+  support: string;
+}
+
+/**
+ * Proposal executed event data
+ */
+export interface ProposalExecutedEvent {
+  proposalId: number;
+  success: boolean;
+}
+
+/**
+ * User registered event data
+ */
+export interface UserRegisteredEvent {
+  user: string;
+}
+
+/**
+ * Reputation updated event data
+ */
+export interface ReputationUpdatedEvent {
+  user: string;
+  score: number;
+  delta: number;
+}
+
+/**
+ * Badge earned event data
+ */
+export interface BadgeEarnedEvent {
+  user: string;
+  badge: string;
+}
+
+/**
+ * Payment setup event data
+ */
+export interface PaymentSetupEvent {
+  paymentId: string;
+  payer: string;
+  payee: string;
+}
+
+/**
+ * Payment received event data
+ */
+export interface PaymentReceivedEvent {
+  paymentId: string;
+  amount: string;
+}
+
+/**
+ * Payment withdrawn event data
+ */
+export interface PaymentWithdrawnEvent {
+  paymentId: string;
+  recipient: string;
+  amount: string;
+}
+
+/**
+ * Subscription created event data
+ */
+export interface SubscriptionCreatedEvent {
+  subscriptionId: string;
+  subscriber: string;
+  plan: string;
+  amount: string;
+}
+
+/**
+ * Subscription status event data
+ */
+export interface SubscriptionStatusEvent {
+  subscriptionId: string;
+  status: string;
+}
+
+/**
+ * Subscription modified event data
+ */
+export interface SubscriptionModifiedEvent {
+  subscriptionId: string;
+  plan: string;
+  amount: string;
+}
+
+/**
+ * Payment failed event data
+ */
+export interface PaymentFailedEvent {
+  subscriptionId: string;
+  reason: string;
+}
+
+/**
+ * Subscription payment event data
+ */
+export interface SubscriptionPaymentEvent {
+  subscriptionId: string;
+  amount: string;
+}
+
+/**
+ * Bridge initialized event data
+ */
+export interface BridgeInitializedEvent {
+  bridgeId: string;
+  admin: string;
+}
+
+/**
+ * Supported chain added event data
+ */
+export interface SupportedChainAddedEvent {
+  chainId: number;
+  chainName: string;
+}
+
+/**
+ * Supported chain removed event data
+ */
+export interface SupportedChainRemovedEvent {
+  chainId: number;
+}
+
+/**
+ * Asset wrapped event data
+ */
+export interface AssetWrappedEvent {
+  asset: string;
+  wrappedAsset: string;
+  amount: string;
+}
+
+/**
+ * Asset unwrapped event data
+ */
+export interface AssetUnwrappedEvent {
+  asset: string;
+  amount: string;
+}
+
+/**
+ * Bridge deposit event data
+ */
+export interface BridgeDepositEvent {
+  chainId: number;
+  depositor: string;
+  amount: string;
+}
+
+/**
+ * Bridge withdraw event data
+ */
+export interface BridgeWithdrawEvent {
+  chainId: number;
+  recipient: string;
+  amount: string;
+}
+
+/**
+ * Bridge lifecycle event data
+ */
+export interface BridgeLifecycleEvent {
+  bridgeId: string;
+}
+
+/**
+ * Relayer event data
+ */
+export interface RelayerEvent {
+  relayer: string;
+}
+
+/**
+ * Bridge transaction event data
+ */
+export interface BridgeTxEvent {
+  txHash: string;
+  status: string;
+}
+
+/**
+ * Contract lifecycle event data
+ */
+export interface ContractLifecycleEvent {
+  contractId: string;
+}
+
+/**
+ * Upgrade event data
+ */
+export interface UpgradeEvent {
+  contractId: string;
+  newWasmHash: string;
 }
 
 /**
@@ -150,5 +474,22 @@ export interface FundsReleasedEvent {
  */
 export interface ProjectStatusEvent {
   projectId: number;
-  status: 'completed' | 'failed';
+  status: string;
+}
+
+/**
+ * Event that could not be decoded and was quarantined.
+ * Persisted separately so it can be inspected/retried without blocking
+ * the indexer or corrupting domain tables.
+ */
+export interface QuarantinedEvent {
+  eventId: string;
+  network: string;
+  contractId: string;
+  eventType: ContractEventType;
+  ledgerSeq: number;
+  transactionHash: string;
+  rawXdr: string;
+  reason: string;
+  createdAt: Date;
 }

--- a/src/indexer/types/event-types.ts
+++ b/src/indexer/types/event-types.ts
@@ -186,6 +186,15 @@ export interface FundsLockedEvent {
 }
 
 /**
+ * Funds released event data
+ */
+export interface FundsReleasedEvent {
+  projectId: number;
+  milestoneId: number;
+  amount: string;
+}
+
+/**
  * Milestone created event data
  */
 export interface MilestoneCreatedEvent {


### PR DESCRIPTION
Implemented real Soroban XDR event decoding in the indexer
closes #419

src/indexer/services/indexer.service.ts:405 parseEventData() is a placeholder that returns { rawXdr: valueXdr }. Events are fetched and "processed" but their actual payloads are never decoded, so the indexer ingests opaque blobs and the domain handlers (event-handler.service.ts) cannot act on real on-chain state.

Files affected
src/indexer/services/indexer.service.ts (parseEventData → real xdr.ScVal.fromXDR() decoding)
src/indexer/services/event-handler.service.ts (consume decoded fields per ContractEventType)
src/indexer/types/event-types.ts, src/indexer/types/ledger.types.ts (extend with decoded payload shapes)
src/indexer/interfaces/*, src/indexer/dto/* (typed parsed events)
src/insurance/*, src/user/*, src/reputation/* (react to decoded contribution/milestone/claim events)
Acceptance

Decoded fields (amounts, addresses, statuses) are persisted, not raw XDR.
Unknown/garbage XDR is quarantined (logged, not crashed).
A fixture-based test decodes at least one event per ContractEventType.