### PR TITLE
feat: persist and enforce NotificationSetting on user creation (#426)

### DIFF
--- a/src/notification/services/notification.service.ts
+++ b/src/notification/services/notification.service.ts
@@ -52,14 +52,13 @@ export class NotificationService {
       return;
     }
 
-    // Default settings if none exist
-    const settings = contactData.notificationSettings || {
-      emailEnabled: true,
-      pushEnabled: false,
-      notifyContributions: true,
-      notifyMilestones: true,
-      notifyDeadlines: true,
-    };
+    // Persist default settings if none exist yet (legacy users)
+    let settings = contactData.notificationSettings;
+    if (!settings) {
+      settings = await this.prisma.notificationSetting.create({
+        data: { userId },
+      });
+    }
 
     // Check specific preferences
     if (type === 'CONTRIBUTION' && !settings.notifyContributions) return;

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -132,7 +132,11 @@ export class UserService {
       data: {
         walletAddress: sanitizedAddress, // Keep as-is for unique constraint and public lookup
         email: encryptedEmail,
+        notificationSettings: {
+          create: {},
+        },
       },
+      include: { notificationSettings: true },
     });
   }
 


### PR DESCRIPTION
Closes #426

## What changed

- **src/user/user.service.ts**: `UserService.create()` now creates a `NotificationSetting` row via Prisma nested create (`include: { notificationSettings: true }`) so every new user has persisted notification preferences from the start.

- **src/notification/services/notification.service.ts**: Replaced the in-memory default-settings fallback in `notify()` with a direct `Prisma.notificationSetting.create` for legacy users who lack a row. No per-call default reconstruction in the hot path.

## Why

The notification controller already exposes `PUT /v1/notifications/settings/:userId` (with upsert) and `GET /v1/notifications/settings/:userId`, but users created before this feature had no `NotificationSetting` row — preferences were recomputed as a plain object on every `notify()` call and any update endpoint had nothing to patch.

## Acceptance criteria

- [x] New users get a real `NotificationSetting` row on creation
- [x] Legacy users without settings get a persisted row on first `notify()` call
- [x] Toggling a preference via `PUT /v1/notifications/settings/:userId` persists and is honored on the next `notify()`
- [x] No per-call default reconstruction in the hot path
- [x] `npx tsc --noEmit` passes cleanly
