### PR TITLE
Circuit breaker

### DIFF
--- a/src/common/resilience/circuit-breaker.ts
+++ b/src/common/resilience/circuit-breaker.ts
@@ -1,0 +1,67 @@
+import OpossumCircuitBreaker from 'opossum';
+
+/**
+ * Standardised circuit-breaker configuration backed by opossum. Sensible
+ * defaults are applied in `createCircuitBreaker`, so call sites only override
+ * what matters for their dependency (timeout, thresholds).
+ */
+export interface CircuitBreakerOptions {
+  /** Human-readable name surfaced in logs and opossum metrics. */
+  name: string;
+  /** Percentage of requests in the rolling window that must fail to trip. */
+  errorThresholdPercentage?: number;
+  /** Milliseconds the circuit stays open before one probe request (half-open). */
+  resetTimeout?: number;
+  /** Minimum requests in the rolling window before the threshold applies. */
+  volumeThreshold?: number;
+  /** Rolling window length in milliseconds. */
+  rollingCountTimeout?: number;
+  /** Per-request timeout in milliseconds; fire() rejects when exceeded. */
+  timeout?: number;
+}
+
+/** Shared breaker instance type — opossum's CircuitBreaker. */
+export type CircuitBreaker = OpossumCircuitBreaker;
+
+const DEFAULTS = {
+  errorThresholdPercentage: 50,
+  resetTimeout: 30_000,
+  volumeThreshold: 5,
+  rollingCountTimeout: 10_000,
+  timeout: 10_000,
+} as const;
+
+/**
+ * Create a named circuit breaker around an arbitrary async task.
+ *
+ * The underlying opossum action simply invokes the task closure passed to
+ * `fire`, so a single breaker instance can protect every call site in a
+ * service while keeping the breaker's failure statistics coherent.
+ */
+export function createCircuitBreaker(
+  name: string,
+  options: Partial<Omit<CircuitBreakerOptions, 'name'>> = {},
+): CircuitBreaker {
+  return new OpossumCircuitBreaker(
+    (task: () => Promise<unknown>) => task(),
+    {
+      name,
+      errorThresholdPercentage:
+        options.errorThresholdPercentage ?? DEFAULTS.errorThresholdPercentage,
+      resetTimeout: options.resetTimeout ?? DEFAULTS.resetTimeout,
+      volumeThreshold: options.volumeThreshold ?? DEFAULTS.volumeThreshold,
+      rollingCountTimeout: options.rollingCountTimeout ?? DEFAULTS.rollingCountTimeout,
+      timeout: options.timeout ?? DEFAULTS.timeout,
+    },
+  );
+}
+
+/**
+ * True when the error is opossum's fail-fast "circuit open" rejection
+ * (`CircuitBreakerOpenError`, code `EOPENBREAKER`).
+ */
+export function isCircuitOpenError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const candidate = error as { name?: string; code?: string };
+  return candidate.name === 'CircuitBreakerOpenError' || candidate.code === 'EOPENBREAKER';
+}

--- a/src/common/resilience/resilience.constants.ts
+++ b/src/common/resilience/resilience.constants.ts
@@ -1,0 +1,63 @@
+import { CircuitBreakerOptions } from './circuit-breaker';
+import { RetryOptions } from './retry';
+
+/**
+ * One circuit-breaker + retry policy per external dependency. Services pass
+ * the preset straight to `createCircuitBreaker` / `withResilience`, so every
+ * external client shares the same resilience semantics.
+ *
+ * Policies are deliberately conservative: external calls are allowed a small
+ * number of fast in-process retries with exponential backoff before the
+ * breaker trips and callers fail fast (or use their fallback).
+ */
+export interface ResiliencePolicy {
+  circuitBreaker: Partial<Omit<CircuitBreakerOptions, 'name'>> & { name: string };
+  retry?: RetryOptions;
+}
+
+/** Stellar Soroban RPC (indexer polling: getHealth / getLatestLedger / getEvents). */
+export const STELLAR_RPC_POLICY: ResiliencePolicy = {
+  circuitBreaker: { name: 'stellar-rpc', timeout: 15_000 },
+  retry: { attempts: 3, baseDelayMs: 500, maxDelayMs: 5_000, jitter: true },
+};
+
+/** AWS S3 (upload / presign / delete). */
+export const AWS_S3_POLICY: ResiliencePolicy = {
+  circuitBreaker: { name: 'aws-s3', timeout: 30_000 },
+  retry: { attempts: 3, baseDelayMs: 250, maxDelayMs: 4_000, jitter: true },
+};
+
+/** IPFS (pin metadata / hash verification). */
+export const IPFS_POLICY: ResiliencePolicy = {
+  circuitBreaker: { name: 'ipfs', timeout: 20_000 },
+  retry: { attempts: 2, baseDelayMs: 1_000, maxDelayMs: 4_000, jitter: true },
+};
+
+/** SendGrid (email delivery). Bull already retries the job, so keep this short. */
+export const SENDGRID_POLICY: ResiliencePolicy = {
+  circuitBreaker: { name: 'sendgrid', timeout: 15_000 },
+  retry: { attempts: 2, baseDelayMs: 500, maxDelayMs: 3_000, jitter: true },
+};
+
+/** Web push (VAPID delivery). */
+export const WEB_PUSH_POLICY: ResiliencePolicy = {
+  circuitBreaker: { name: 'web-push', timeout: 15_000 },
+  retry: { attempts: 2, baseDelayMs: 500, maxDelayMs: 3_000, jitter: true },
+};
+
+/** Redis-backed cache (nonce store). */
+export const REDIS_NONCE_POLICY: ResiliencePolicy = {
+  circuitBreaker: { name: 'redis-nonce', timeout: 3_000 },
+  retry: { attempts: 2, baseDelayMs: 200, maxDelayMs: 1_000, jitter: true },
+};
+
+/** Bull queue enqueues (email / push / IPFS pin jobs — Redis-backed). */
+export const BULL_QUEUE_POLICY: ResiliencePolicy = {
+  circuitBreaker: { name: 'bull-queue', timeout: 5_000 },
+  retry: { attempts: 2, baseDelayMs: 200, maxDelayMs: 1_000, jitter: true },
+};
+
+/** Idempotency-key COMPLETED write guard (DB, not external — kept for parity). */
+export const IDEMPOTENCY_DB_POLICY: ResiliencePolicy = {
+  circuitBreaker: { name: 'idempotency-db', timeout: 5_000 },
+};

--- a/src/common/resilience/resilience.spec.ts
+++ b/src/common/resilience/resilience.spec.ts
@@ -1,0 +1,179 @@
+import {
+  createCircuitBreaker,
+  isCircuitOpenError,
+} from './circuit-breaker';
+import { computeBackoffDelay, withRetry } from './retry';
+import { withResilience } from './resilience';
+
+describe('computeBackoffDelay', () => {
+  it('doubles the base delay on each attempt', () => {
+    const options = { attempts: 4, baseDelayMs: 100, jitter: false };
+    expect(computeBackoffDelay(1, options)).toBe(100);
+    expect(computeBackoffDelay(2, options)).toBe(200);
+    expect(computeBackoffDelay(3, options)).toBe(400);
+  });
+
+  it('caps the delay at maxDelayMs', () => {
+    const options = { attempts: 6, baseDelayMs: 100, maxDelayMs: 250, jitter: false };
+    expect(computeBackoffDelay(4, options)).toBe(250);
+    expect(computeBackoffDelay(5, options)).toBe(250);
+  });
+
+  it('applies 50-100% jitter when enabled', () => {
+    const options = { attempts: 3, baseDelayMs: 1000, jitter: true };
+    const delay = computeBackoffDelay(2, options);
+    expect(delay).toBeGreaterThanOrEqual(500);
+    expect(delay).toBeLessThanOrEqual(1000);
+  });
+});
+
+describe('withRetry', () => {
+  it('succeeds on the second attempt', async () => {
+    const operation = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce('ok');
+
+    await expect(
+      withRetry(operation, { attempts: 3, baseDelayMs: 1 }),
+    ).resolves.toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('exhausts attempts and throws the last error', async () => {
+    const operation = jest.fn().mockRejectedValue(new Error('down'));
+
+    await expect(
+      withRetry(operation, { attempts: 3, baseDelayMs: 1 }),
+    ).rejects.toThrow('down');
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops early when retryIf says the error is not retryable', async () => {
+    const operation = jest.fn().mockRejectedValue(new Error('4xx'));
+
+    await expect(
+      withRetry(operation, {
+        attempts: 5,
+        baseDelayMs: 1,
+        retryIf: () => false,
+      }),
+    ).rejects.toThrow('4xx');
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('withResilience', () => {
+  it('passes through successful results', async () => {
+    const breaker = createCircuitBreaker('chaos-success');
+    await expect(withResilience(breaker, () => Promise.resolve(42))).resolves.toBe(42);
+  });
+
+  it('retries non-open failures and succeeds', async () => {
+    const breaker = createCircuitBreaker('chaos-retry', {
+      errorThresholdPercentage: 50,
+      volumeThreshold: 3, // 2 failures must NOT trip the circuit
+      resetTimeout: 60_000,
+    });
+    const task = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('rpc down'))
+      .mockRejectedValueOnce(new Error('rpc down'))
+      .mockResolvedValueOnce('ok');
+
+    await expect(
+      withResilience(breaker, task, {
+        retry: { attempts: 3, baseDelayMs: 1, jitter: false },
+      }),
+    ).resolves.toBe('ok');
+    expect(task).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws the underlying error after retries are exhausted', async () => {
+    const breaker = createCircuitBreaker('chaos-exhausted', {
+      errorThresholdPercentage: 50,
+      volumeThreshold: 10, // never trips during this test
+      resetTimeout: 60_000,
+    });
+    const task = jest.fn().mockRejectedValue(new Error('down'));
+
+    await expect(
+      withResilience(breaker, task, {
+        retry: { attempts: 3, baseDelayMs: 1, jitter: false },
+      }),
+    ).rejects.toThrow('down');
+    expect(task).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails fast without invoking the task once the circuit is open', async () => {
+    const breaker = createCircuitBreaker('chaos-open', {
+      errorThresholdPercentage: 100,
+      volumeThreshold: 1,
+      resetTimeout: 60_000,
+    });
+    let calls = 0;
+    const task = () => {
+      calls++;
+      return Promise.reject(new Error('boom'));
+    };
+
+    let openError: unknown;
+    for (let i = 0; i < 5 && !openError; i++) {
+      try {
+        await withResilience(breaker, task);
+      } catch (error) {
+        if (isCircuitOpenError(error)) {
+          openError = error;
+        } else {
+          expect((error as Error).message).toBe('boom');
+        }
+      }
+    }
+
+    expect(openError).toBeDefined();
+    const callsWhenOpen = calls;
+    await expect(withResilience(breaker, task)).rejects.toMatchObject({
+      code: 'EOPENBREAKER',
+    });
+    expect(calls).toBe(callsWhenOpen);
+  });
+
+  it('invokes the fallback when the circuit is open', async () => {
+    const breaker = createCircuitBreaker('chaos-fallback', {
+      errorThresholdPercentage: 100,
+      volumeThreshold: 1,
+      resetTimeout: 60_000,
+    });
+    const task = () => Promise.reject(new Error('boom'));
+
+    await withResilience(breaker, task).catch(() => undefined);
+
+    await expect(
+      withResilience(breaker, task, { fallback: () => 'fallback-value' }),
+    ).resolves.toBe('fallback-value');
+  });
+
+  it('allows a probe request after the reset timeout (half-open recovery)', async () => {
+    const breaker = createCircuitBreaker('chaos-recovery', {
+      errorThresholdPercentage: 100,
+      volumeThreshold: 1,
+      resetTimeout: 20,
+    });
+    const task = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue('recovered');
+
+    await expect(withResilience(breaker, task)).rejects.toThrow('boom');
+    // Circuit is now open — second call fails fast, task not invoked.
+    await expect(withResilience(breaker, task)).rejects.toMatchObject({
+      code: 'EOPENBREAKER',
+    });
+    expect(task).toHaveBeenCalledTimes(1);
+
+    // After resetTimeout elapses, the next call is a probe that may succeed.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await expect(withResilience(breaker, task)).resolves.toBe('recovered');
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/common/resilience/resilience.ts
+++ b/src/common/resilience/resilience.ts
@@ -1,0 +1,56 @@
+import { CircuitBreaker, isCircuitOpenError } from './circuit-breaker';
+import { RetryOptions, computeBackoffDelay, sleep } from './retry';
+
+export interface WithResilienceOptions<T> {
+  /** Exponential-backoff retry policy applied to non-open failures. */
+  retry?: RetryOptions;
+  /**
+   * Result returned instead of throwing once the circuit is open — the
+   * standardised "fail fast, don't pile onto a degraded dependency" hook.
+   */
+  fallback?: () => T | Promise<T>;
+}
+
+/**
+ * Run `task` through a shared circuit breaker, applying exponential-backoff
+ * retries (when configured) and failing fast with a fallback once the circuit
+ * is open.
+ *
+ * - Each `fire` is a single breaker event: repeated failures trip the circuit.
+ * - Once open, `fire` rejects immediately with opossum's
+ *   `CircuitBreakerOpenError`; retries stop and the optional fallback runs.
+ * - A success resets the breaker's failure count.
+ */
+export async function withResilience<T>(
+  breaker: CircuitBreaker,
+  task: () => Promise<T>,
+  options: WithResilienceOptions<T> = {},
+): Promise<T> {
+  const { retry, fallback } = options;
+  const attempts = retry ? Math.max(1, retry.attempts) : 1;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return (await breaker.fire(task)) as T;
+    } catch (error) {
+      lastError = error;
+
+      // Circuit open: fire() fails fast — stop retrying immediately.
+      if (isCircuitOpenError(error)) {
+        break;
+      }
+
+      const shouldRetry =
+        retry && attempt < attempts && (retry.retryIf ? retry.retryIf(error, attempt) : true);
+      if (!shouldRetry) break;
+
+      await sleep(computeBackoffDelay(attempt, retry));
+    }
+  }
+
+  if (isCircuitOpenError(lastError) && fallback) {
+    return fallback();
+  }
+  throw lastError;
+}

--- a/src/common/resilience/resilience.ts
+++ b/src/common/resilience/resilience.ts
@@ -46,7 +46,7 @@ export async function withResilience<T>(
       if (!shouldRetry) break;
 
       const delay = computeBackoffDelay(attempt, retry);
-      retry.onRetry?.(error, attempt, delay);
+      retry?.onRetry?.(error, attempt, delay);
       await sleep(delay);
     }
   }

--- a/src/common/resilience/resilience.ts
+++ b/src/common/resilience/resilience.ts
@@ -45,7 +45,9 @@ export async function withResilience<T>(
         retry && attempt < attempts && (retry.retryIf ? retry.retryIf(error, attempt) : true);
       if (!shouldRetry) break;
 
-      await sleep(computeBackoffDelay(attempt, retry));
+      const delay = computeBackoffDelay(attempt, retry);
+      retry.onRetry?.(error, attempt, delay);
+      await sleep(delay);
     }
   }
 

--- a/src/common/resilience/retry.ts
+++ b/src/common/resilience/retry.ts
@@ -9,6 +9,8 @@ export interface RetryOptions {
   jitter?: boolean;
   /** Decide whether a given failure is retryable. Defaults to retrying all. */
   retryIf?: (error: unknown, attempt: number) => boolean;
+  /** Called before a retry with the failed attempt number and the delay chosen. */
+  onRetry?: (error: unknown, attempt: number, delayMs: number) => void;
 }
 
 /**
@@ -43,7 +45,9 @@ export async function withRetry<T>(
       lastError = error;
       const retryable = options.retryIf ? options.retryIf(error, attempt) : true;
       if (attempt >= options.attempts || !retryable) throw error;
-      await sleep(computeBackoffDelay(attempt, options));
+      const delay = computeBackoffDelay(attempt, options);
+      options.onRetry?.(error, attempt, delay);
+      await sleep(delay);
     }
   }
   throw lastError;

--- a/src/common/resilience/retry.ts
+++ b/src/common/resilience/retry.ts
@@ -1,0 +1,50 @@
+export interface RetryOptions {
+  /** Total attempts including the first (must be >= 1). */
+  attempts: number;
+  /** Base exponential-backoff delay in ms (doubles each attempt). */
+  baseDelayMs: number;
+  /** Optional upper bound for the backoff delay in ms. */
+  maxDelayMs?: number;
+  /** Apply 50-100% random jitter to each delay (avoid thundering herds). */
+  jitter?: boolean;
+  /** Decide whether a given failure is retryable. Defaults to retrying all. */
+  retryIf?: (error: unknown, attempt: number) => boolean;
+}
+
+/**
+ * Exponential backoff with optional jitter:
+ * `base * 2^(attempt - 1)`, capped at `maxDelayMs` when provided.
+ */
+export function computeBackoffDelay(attempt: number, options: RetryOptions): number {
+  const exponent = Math.max(0, attempt - 1);
+  const exponential = options.baseDelayMs * 2 ** exponent;
+  const capped = Math.min(exponential, options.maxDelayMs ?? exponential);
+  if (!options.jitter) return capped;
+  return Math.round(capped * (0.5 + Math.random() * 0.5));
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `operation`, retrying failures with exponential backoff (and optional
+ * jitter) until it succeeds, `attempts` is exhausted, or `retryIf` says stop.
+ */
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions,
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= options.attempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      const retryable = options.retryIf ? options.retryIf(error, attempt) : true;
+      if (attempt >= options.attempts || !retryable) throw error;
+      await sleep(computeBackoffDelay(attempt, options));
+    }
+  }
+  throw lastError;
+}

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -168,14 +168,6 @@ class EnvironmentVariables {
 
   @IsNumber()
   @IsOptional()
-  INDEXER_RETRY_ATTEMPTS: number = 3;
-
-  @IsNumber()
-  @IsOptional()
-  INDEXER_RETRY_DELAY_MS: number = 1000;
-
-  @IsNumber()
-  @IsOptional()
   THROTTLE_DEFAULT_TTL: number = 900000;
 
   @IsNumber()

--- a/src/config/stellar.config.ts
+++ b/src/config/stellar.config.ts
@@ -18,8 +18,6 @@ export interface IndexerConfig {
   startLedger?: number;
   reorgDepthThreshold: number;
   maxEventsPerFetch: number;
-  retryAttempts: number;
-  retryDelayMs: number;
 }
 
 export default registerAs('stellar', () => ({
@@ -42,6 +40,4 @@ export const indexerConfig = registerAs('indexer', () => ({
     : undefined,
   reorgDepthThreshold: parseInt(process.env.INDEXER_REORG_DEPTH_THRESHOLD || '5', 10),
   maxEventsPerFetch: parseInt(process.env.INDEXER_MAX_EVENTS_PER_FETCH || '100', 10),
-  retryAttempts: parseInt(process.env.INDEXER_RETRY_ATTEMPTS || '3', 10),
-  retryDelayMs: parseInt(process.env.INDEXER_RETRY_DELAY_MS || '1000', 10),
 }));

--- a/src/indexer/services/indexer.service.spec.ts
+++ b/src/indexer/services/indexer.service.spec.ts
@@ -1,0 +1,77 @@
+import { IndexerService } from './indexer.service';
+
+describe('IndexerService — chaos (Stellar RPC outage)', () => {
+  const configService = {
+    get: jest.fn((key: string, def?: unknown) => {
+      const map: Record<string, unknown> = {
+        STELLAR_NETWORK: 'testnet',
+        STELLAR_RPC_URL: 'https://soroban-testnet.stellar.org',
+        INDEXER_POLL_INTERVAL_MS: 5000,
+        INDEXER_MAX_EVENTS_PER_FETCH: 100,
+      };
+      return key in map ? map[key] : def;
+    }),
+  };
+  const quarantinedEventRepository = { upsertEvent: jest.fn() };
+  const ledgerTracker = {
+    getLastCursor: jest.fn(),
+    isEventProcessed: jest.fn(),
+    markEventProcessed: jest.fn(),
+    updateCursor: jest.fn(),
+    logError: jest.fn(),
+    logProgress: jest.fn(),
+  };
+  const eventHandler = { processEvent: jest.fn() };
+  const xdrDecoder = {};
+  const schedulerRegistry = { addInterval: jest.fn(), deleteInterval: jest.fn() };
+
+  let service: IndexerService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new IndexerService(
+      configService as any,
+      quarantinedEventRepository as any,
+      ledgerTracker as any,
+      eventHandler as any,
+      xdrDecoder as any,
+      schedulerRegistry as any,
+    );
+  });
+
+  it('retries RPC getEvents failures with the shared retry policy', async () => {
+    (service as any).rpc = {
+      getEvents: jest.fn().mockRejectedValue(new Error('rpc down')),
+    };
+
+    await expect((service as any).fetchEvents(1, 10)).rejects.toThrow('rpc down');
+    // STELLAR_RPC_POLICY: 3 attempts per RPC call.
+    expect((service as any).rpc.getEvents).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails fast once the RPC circuit is open — no further RPC calls', async () => {
+    (service as any).rpc = {
+      getEvents: jest.fn().mockRejectedValue(new Error('rpc down')),
+    };
+
+    // Drive enough failures to trip the breaker (volumeThreshold 5, 3 fires/call).
+    for (let i = 0; i < 3; i++) {
+      await (service as any).fetchEvents(1, 10).catch(() => undefined);
+    }
+    const callsAfterTrips = (service as any).rpc.getEvents.mock.calls.length;
+
+    await (service as any).fetchEvents(1, 10).catch(() => undefined);
+    expect((service as any).rpc.getEvents.mock.calls.length).toBe(
+      callsAfterTrips,
+    );
+  });
+
+  it('resolves the latest ledger sequence through the breaker', async () => {
+    (service as any).rpc = {
+      getLatestLedger: jest.fn().mockResolvedValue({ sequence: 42 }),
+    };
+
+    await expect((service as any).getLatestLedger()).resolves.toBe(42);
+    expect((service as any).rpc.getLatestLedger).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/indexer/services/indexer.service.ts
+++ b/src/indexer/services/indexer.service.ts
@@ -11,6 +11,9 @@ import { SorobanEvent, ParsedContractEvent, ContractEventType } from '../types/e
 import { LedgerInfo } from '../types/ledger.types';
 import { QuarantinedEventRepository } from '../../common/repositories/indexer.repository';
 import { runWithTracingContext } from '../../common/tracing/tracing-context';
+import { createCircuitBreaker, CircuitBreaker } from '../../common/resilience/circuit-breaker';
+import { withResilience } from '../../common/resilience/resilience';
+import { STELLAR_RPC_POLICY } from '../../common/resilience/resilience.constants';
 
 /**
  * Main indexer service that polls Stellar RPC for contract events
@@ -23,9 +26,8 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
   private readonly network: string;
   private pollIntervalMs: number;
   private readonly maxEventsPerFetch: number;
-  private readonly retryAttempts: number;
-  private readonly retryDelayMs: number;
   private readonly contractIds: string[];
+  private readonly rpcBreaker: CircuitBreaker;
 
   private isRunning = false;
   private isShuttingDown = false;
@@ -46,13 +48,18 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
     );
     this.pollIntervalMs = this.configService.get<number>('INDEXER_POLL_INTERVAL_MS', 5000);
     this.maxEventsPerFetch = this.configService.get<number>('INDEXER_MAX_EVENTS_PER_FETCH', 100);
-    this.retryAttempts = this.configService.get<number>('INDEXER_RETRY_ATTEMPTS', 3);
-    this.retryDelayMs = this.configService.get<number>('INDEXER_RETRY_DELAY_MS', 1000);
 
     // Initialize RPC client
     this.rpc = new SorobanRpc.Server(rpcUrl, {
       allowHttp: rpcUrl.startsWith('http://'),
     });
+
+    // Circuit breaker + retry policy for every Stellar RPC call. When the RPC
+    // endpoint degrades, polling fails fast instead of hanging the indexer.
+    this.rpcBreaker = createCircuitBreaker(
+      STELLAR_RPC_POLICY.circuitBreaker.name,
+      STELLAR_RPC_POLICY.circuitBreaker,
+    );
 
     // Get contract IDs to monitor
     this.contractIds = this.getContractIds();
@@ -125,7 +132,11 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
   private async initializeIndexer(): Promise<void> {
     try {
       // Test RPC connection
-      const health = await this.rpc.getHealth();
+      const health = await withResilience(
+        this.rpcBreaker,
+        () => this.rpc.getHealth(),
+        { retry: STELLAR_RPC_POLICY.retry },
+      );
       this.logger.log(`RPC Health: ${health.status}`);
 
       // Get latest ledger
@@ -210,8 +221,8 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
 
       this.logger.log(`Polling events from ledger ${startLedger} to ${latestLedger}`);
 
-      // Fetch events with retry logic
-      const events = await this.fetchEventsWithRetry(startLedger, latestLedger);
+      // Fetch events (retries + circuit breaker applied inside fetchEvents)
+      const events = await this.fetchEvents(startLedger, latestLedger);
 
       if (events.length === 0) {
         this.logger.debug('No events found in ledger range');
@@ -269,36 +280,9 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * Fetch events from RPC with retry logic
-   */
-  private async fetchEventsWithRetry(
-    startLedger: number,
-    endLedger: number,
-  ): Promise<SorobanEvent[]> {
-    let lastError: Error | null = null;
-
-    for (let attempt = 1; attempt <= this.retryAttempts; attempt++) {
-      try {
-        return await this.fetchEvents(startLedger, endLedger);
-      } catch (error) {
-        lastError = error;
-        this.logger.warn(`Fetch attempt ${attempt}/${this.retryAttempts} failed: ${error.message}`);
-
-        if (attempt < this.retryAttempts) {
-          const delay = this.retryDelayMs * Math.pow(2, attempt - 1); // Exponential backoff
-          this.logger.log(`Retrying in ${delay}ms...`);
-          await this.sleep(delay);
-        }
-      }
-    }
-
-    throw new Error(
-      `Failed to fetch events after ${this.retryAttempts} attempts: ${lastError?.message}`,
-    );
-  }
-
-  /**
-   * Fetch events from Soroban RPC
+   * Fetch events from Soroban RPC — every getEvents call runs through the
+   * shared circuit breaker with exponential-backoff retries, so a degraded
+   * RPC endpoint trips the breaker instead of wedging the poll loop.
    */
   private async fetchEvents(startLedger: number, endLedger: number): Promise<SorobanEvent[]> {
     const events: SorobanEvent[] = [];
@@ -330,7 +314,11 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
         cursor,
       };
 
-      const response = await this.rpc.getEvents(request);
+      const response = await withResilience(
+        this.rpcBreaker,
+        () => this.rpc.getEvents(request),
+        { retry: STELLAR_RPC_POLICY.retry },
+      );
 
       if (response.events) {
         for (const event of response.events) {
@@ -514,7 +502,11 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
    * Get latest ledger from RPC
    */
   private async getLatestLedger(): Promise<number> {
-    const latestLedger = await this.rpc.getLatestLedger();
+    const latestLedger = await withResilience(
+      this.rpcBreaker,
+      () => this.rpc.getLatestLedger(),
+      { retry: STELLAR_RPC_POLICY.retry },
+    );
     return latestLedger.sequence;
   }
 

--- a/src/indexer/services/indexer.service.ts
+++ b/src/indexer/services/indexer.service.ts
@@ -13,6 +13,7 @@ import { QuarantinedEventRepository } from '../../common/repositories/indexer.re
 import { runWithTracingContext } from '../../common/tracing/tracing-context';
 import { createCircuitBreaker, CircuitBreaker } from '../../common/resilience/circuit-breaker';
 import { withResilience } from '../../common/resilience/resilience';
+import { RetryOptions } from '../../common/resilience/retry';
 import { STELLAR_RPC_POLICY } from '../../common/resilience/resilience.constants';
 
 /**
@@ -135,7 +136,7 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
       const health = await withResilience(
         this.rpcBreaker,
         () => this.rpc.getHealth(),
-        { retry: STELLAR_RPC_POLICY.retry },
+        { retry: this.rpcRetryPolicy() },
       );
       this.logger.log(`RPC Health: ${health.status}`);
 
@@ -317,7 +318,7 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
       const response = await withResilience(
         this.rpcBreaker,
         () => this.rpc.getEvents(request),
-        { retry: STELLAR_RPC_POLICY.retry },
+        { retry: this.rpcRetryPolicy() },
       );
 
       if (response.events) {
@@ -499,13 +500,30 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
+   * STELLAR_RPC_POLICY retry config with indexer logging, so RPC degradation
+   * stays visible (the old manual retry loop logged every attempt).
+   */
+  private rpcRetryPolicy(): RetryOptions {
+    return {
+      ...STELLAR_RPC_POLICY.retry,
+      onRetry: (error: unknown, attempt: number, delayMs: number) => {
+        this.logger.warn(
+          `Stellar RPC request failed (attempt ${attempt}), retrying in ${delayMs}ms: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      },
+    };
+  }
+
+  /**
    * Get latest ledger from RPC
    */
   private async getLatestLedger(): Promise<number> {
     const latestLedger = await withResilience(
       this.rpcBreaker,
       () => this.rpc.getLatestLedger(),
-      { retry: STELLAR_RPC_POLICY.retry },
+      { retry: this.rpcRetryPolicy() },
     );
     return latestLedger.sequence;
   }

--- a/src/interceptors/idempotency.service.ts
+++ b/src/interceptors/idempotency.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma.service';
-import { CircuitBreaker } from './utils/circuit-breaker';
+import { createCircuitBreaker, CircuitBreaker } from '../common/resilience/circuit-breaker';
+import { withResilience } from '../common/resilience/resilience';
+import { IDEMPOTENCY_DB_POLICY } from '../common/resilience/resilience.constants';
 
 /** Everything the interceptor knows when it claims an idempotency key. */
 export interface IdempotencyClaim {
@@ -37,7 +39,10 @@ export interface IdempotencyKeyRecord {
 @Injectable()
 export class IdempotencyService {
   private readonly logger = new Logger(IdempotencyService.name);
-  private readonly circuitBreaker = new CircuitBreaker();
+  private readonly circuitBreaker: CircuitBreaker = createCircuitBreaker(
+    IDEMPOTENCY_DB_POLICY.circuitBreaker.name,
+    IDEMPOTENCY_DB_POLICY.circuitBreaker,
+  );
 
   constructor(private readonly prisma: PrismaService) {}
 
@@ -89,17 +94,19 @@ export class IdempotencyService {
 
   /** Record the cached response after the handler completed successfully. */
   async markCompleted(key: string, response: unknown, statusCode: number): Promise<void> {
-    await this.circuitBreaker.execute(() =>
-      this.prisma.idempotencyKey.update({
-        where: { key },
-        data: {
-          status: 'COMPLETED',
-          response: {
-            data: response,
-            statusCode,
-          } as unknown as Prisma.InputJsonValue,
-        },
-      }),
+    await withResilience(
+      this.circuitBreaker,
+      () =>
+        this.prisma.idempotencyKey.update({
+          where: { key },
+          data: {
+            status: 'COMPLETED',
+            response: {
+              data: response,
+              statusCode,
+            } as unknown as Prisma.InputJsonValue,
+          },
+        }),
     );
   }
 

--- a/src/interceptors/utils/circuit-breaker.ts
+++ b/src/interceptors/utils/circuit-breaker.ts
@@ -1,54 +1,14 @@
-export class CircuitBreaker {
-  private failureCount = 0;
-  private lastFailureTime: number | null = null;
-  private isOpen = false;
-  private readonly threshold: number;
-  private readonly resetTimeout: number;
+/**
+ * Compatibility shim.
+ *
+ * The standardised circuit-breaker utilities now live in
+ * `src/common/resilience/`. This module is kept so pre-existing imports of
+ * `CircuitBreaker` / `idempotencyCircuitBreaker` keep resolving; new code
+ * should import from `src/common/resilience` directly.
+ */
+import { createCircuitBreaker } from '../../common/resilience/circuit-breaker';
 
-  constructor(threshold = 5, resetTimeoutMs = 30000) {
-    this.threshold = threshold;
-    this.resetTimeout = resetTimeoutMs;
-  }
+export type { CircuitBreaker, CircuitBreakerOptions } from '../../common/resilience/circuit-breaker';
 
-  async execute<T>(operation: () => Promise<T>): Promise<T> {
-    if (this.isOpen) {
-      this.checkResetTimeout();
-      if (this.isOpen) {
-        throw new Error('Circuit breaker is open - service temporarily unavailable');
-      }
-    }
-
-    try {
-      const result = await operation();
-      this.reset();
-      return result;
-    } catch (error) {
-      this.recordFailure();
-      throw error;
-    }
-  }
-
-  private recordFailure(): void {
-    this.failureCount++;
-    this.lastFailureTime = Date.now();
-    
-    if (this.failureCount >= this.threshold) {
-      this.isOpen = true;
-    }
-  }
-
-  private reset(): void {
-    this.failureCount = 0;
-    this.lastFailureTime = null;
-    this.isOpen = false;
-  }
-
-  private checkResetTimeout(): void {
-    if (this.isOpen && this.lastFailureTime && Date.now() - this.lastFailureTime > this.resetTimeout) {
-      this.reset();
-    }
-  }
-}
-
-// Singleton instance for idempotency interceptor
-export const idempotencyCircuitBreaker = new CircuitBreaker();
+// Preserved singleton name for any existing importer.
+export const idempotencyCircuitBreaker = createCircuitBreaker('idempotency-db');

--- a/src/nonce/nonce.service.spec.ts
+++ b/src/nonce/nonce.service.spec.ts
@@ -114,4 +114,39 @@ describe('NonceService', () => {
       expect(cache.del).not.toHaveBeenCalled();
     });
   });
+
+  describe('chaos — Redis (cache) outage', () => {
+    it('retries transient failures then throws the underlying error', async () => {
+      cache.set.mockRejectedValue(new Error('redis down'));
+
+      await expect(service.generateNonce()).rejects.toThrow('redis down');
+      // REDIS_NONCE_POLICY: 2 attempts per store write.
+      expect(cache.set).toHaveBeenCalledTimes(2);
+    });
+
+    it('fails fast once the circuit is open instead of hanging', async () => {
+      cache.set.mockRejectedValue(new Error('redis down'));
+
+      let openError: unknown;
+      for (let i = 0; i < 10 && !openError; i++) {
+        try {
+          await service.generateNonce();
+        } catch (error) {
+          if ((error as { code?: string })?.code === 'EOPENBREAKER') {
+            openError = error;
+          }
+        }
+      }
+
+      expect(openError).toBeDefined();
+    });
+
+    it('throws when the Redis read fails during consumption', async () => {
+      cache.get.mockRejectedValue(new Error('redis down'));
+
+      await expect(service.consumeNonce('valid-nonce')).rejects.toThrow(
+        'redis down',
+      );
+    });
+  });
 });

--- a/src/nonce/nonce.service.ts
+++ b/src/nonce/nonce.service.ts
@@ -7,6 +7,9 @@ import {
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { randomBytes } from 'crypto';
+import { createCircuitBreaker, CircuitBreaker } from '../common/resilience/circuit-breaker';
+import { withResilience } from '../common/resilience/resilience';
+import { REDIS_NONCE_POLICY } from '../common/resilience/resilience.constants';
 
 /**
  * NonceService
@@ -33,6 +36,15 @@ export class NonceService {
 
   private readonly NONCE_PREFIX = 'nonce:';
 
+  /**
+   * Circuit breaker protecting the Redis-backed cache: when Redis degrades,
+   * nonce operations fail fast instead of hanging or retrying indefinitely.
+   */
+  private readonly redisBreaker: CircuitBreaker = createCircuitBreaker(
+    REDIS_NONCE_POLICY.circuitBreaker.name,
+    REDIS_NONCE_POLICY.circuitBreaker,
+  );
+
   constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {}
 
   /**
@@ -44,7 +56,11 @@ export class NonceService {
     const key = this.buildKey(nonce);
 
     // Store with TTL — value is the creation timestamp for audit purposes.
-    await this.cache.set(key, Date.now().toString(), this.NONCE_TTL_MS);
+    await withResilience(
+      this.redisBreaker,
+      () => this.cache.set(key, Date.now().toString(), this.NONCE_TTL_MS),
+      { retry: REDIS_NONCE_POLICY.retry },
+    );
 
     this.logger.debug(`Nonce generated: ${nonce}`);
     return nonce;
@@ -65,7 +81,11 @@ export class NonceService {
     }
 
     const key = this.buildKey(nonce);
-    const stored = await this.cache.get<string>(key);
+    const stored = await withResilience(
+      this.redisBreaker,
+      () => this.cache.get<string>(key),
+      { retry: REDIS_NONCE_POLICY.retry },
+    );
 
     if (!stored) {
       this.logger.warn(`Nonce validation failed — unknown or expired: ${nonce}`);
@@ -75,7 +95,11 @@ export class NonceService {
     }
 
     // Delete immediately so it cannot be replayed.
-    await this.cache.del(key);
+    await withResilience(
+      this.redisBreaker,
+      () => this.cache.del(key),
+      { retry: REDIS_NONCE_POLICY.retry },
+    );
 
     this.logger.debug(`Nonce consumed: ${nonce}`);
     return true;
@@ -87,7 +111,11 @@ export class NonceService {
    */
   async isNonceValid(nonce: string): Promise<boolean> {
     if (!nonce) return false;
-    const stored = await this.cache.get<string>(this.buildKey(nonce));
+    const stored = await withResilience(
+      this.redisBreaker,
+      () => this.cache.get<string>(this.buildKey(nonce)),
+      { retry: REDIS_NONCE_POLICY.retry },
+    );
     return stored !== null && stored !== undefined;
   }
 

--- a/src/notification/services/email.service.spec.ts
+++ b/src/notification/services/email.service.spec.ts
@@ -4,6 +4,7 @@ import { EmailOutboxRepository } from '../../common/repositories/notification.re
 import { ConfigService } from '@nestjs/config';
 import { getQueueToken } from '@nestjs/bull';
 import { QUEUE_NAMES } from '../constants/queue.constants';
+import * as sgMail from '@sendgrid/mail';
 
 // Mock @sendgrid/mail so the constructor doesn't throw in unit test context
 jest.mock('@sendgrid/mail', () => ({
@@ -13,14 +14,20 @@ jest.mock('@sendgrid/mail', () => ({
 
 describe('EmailService', () => {
   let service: EmailService;
+  const emailOutboxRepository = { updateStatus: jest.fn() };
+  const sgMailMock = jest.requireMock('@sendgrid/mail') as {
+    send: jest.Mock;
+    setApiKey: jest.Mock;
+  };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EmailService,
         {
           provide: EmailOutboxRepository,
-          useValue: { updateStatus: jest.fn() },
+          useValue: emailOutboxRepository,
         },
         {
           provide: ConfigService,
@@ -44,5 +51,55 @@ describe('EmailService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('chaos — SendGrid outage', () => {
+    const job = {
+      data: {
+        outboxId: 'outbox-1',
+        to: 'user@example.com',
+        subject: 'Hi',
+        html: '<p>hi</p>',
+      },
+      attemptsMade: 0,
+    };
+
+    it('retries internally, marks the outbox PENDING, and rethrows for Bull backoff', async () => {
+      sgMailMock.send.mockRejectedValue(new Error('sendgrid down'));
+
+      await expect(service.handleEmailJob(job as any)).rejects.toThrow(
+        'sendgrid down',
+      );
+      // SENDGRID_POLICY: 2 attempts per delivery.
+      expect(sgMailMock.send).toHaveBeenCalledTimes(2);
+      expect(emailOutboxRepository.updateStatus).toHaveBeenCalledWith(
+        'outbox-1',
+        expect.objectContaining({
+          attempts: 1,
+          status: 'PENDING',
+          lastError: 'sendgrid down',
+        }),
+      );
+    });
+
+    it('fails fast once the circuit is open', async () => {
+      sgMailMock.send.mockRejectedValue(new Error('sendgrid down'));
+
+      let openError: unknown;
+      for (let i = 0; i < 10 && !openError; i++) {
+        try {
+          await service.handleEmailJob({
+            ...job,
+            data: { ...job.data, outboxId: `outbox-${i}` },
+          } as any);
+        } catch (error) {
+          if ((error as { code?: string })?.code === 'EOPENBREAKER') {
+            openError = error;
+          }
+        }
+      }
+
+      expect(openError).toBeDefined();
+    });
   });
 });

--- a/src/notification/services/email.service.spec.ts
+++ b/src/notification/services/email.service.spec.ts
@@ -2,8 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { EmailService } from './email.service';
 import { EmailOutboxRepository } from '../../common/repositories/notification.repository';
 import { ConfigService } from '@nestjs/config';
-import { getQueueToken } from '@nestjs/bull';
-import { QUEUE_NAMES } from '../constants/queue.constants';
 import * as sgMail from '@sendgrid/mail';
 
 // Mock @sendgrid/mail so the constructor doesn't throw in unit test context
@@ -38,10 +36,6 @@ describe('EmailService', () => {
               return undefined;
             }),
           },
-        },
-        {
-          provide: getQueueToken(QUEUE_NAMES.EMAIL),
-          useValue: { add: jest.fn() },
         },
       ],
     }).compile();

--- a/src/notification/services/email.service.ts
+++ b/src/notification/services/email.service.ts
@@ -9,6 +9,9 @@ import { PrismaService } from '../../prisma.service';
 import { runWithTracingContext } from '../../common/tracing/tracing-context';
 
 import { ConfigService } from '@nestjs/config';
+import { createCircuitBreaker, CircuitBreaker } from '../../common/resilience/circuit-breaker';
+import { withResilience } from '../../common/resilience/resilience';
+import { SENDGRID_POLICY } from '../../common/resilience/resilience.constants';
 
 @Injectable()
 @Processor(QUEUE_NAMES.EMAIL)
@@ -16,6 +19,16 @@ export class EmailService {
   private readonly logger = new Logger(EmailService.name);
   private readonly apiKey: string;
   private readonly fromEmail: string;
+
+  /**
+   * Circuit breaker + retry for SendGrid. A degraded SendGrid trips the
+   * breaker so the Bull worker fails fast and retries the job later (via the
+   * job's own backoff) instead of hammering the API.
+   */
+  private readonly emailBreaker: CircuitBreaker = createCircuitBreaker(
+    SENDGRID_POLICY.circuitBreaker.name,
+    SENDGRID_POLICY.circuitBreaker,
+  );
 
   constructor(
     private readonly emailOutboxRepository: EmailOutboxRepository,
@@ -56,7 +69,11 @@ export class EmailService {
     }
 
     try {
-      await sgMail.send({ to, from: this.fromEmail, subject, html });
+      await withResilience(
+        this.emailBreaker,
+        () => sgMail.send({ to, from: this.fromEmail, subject, html }),
+        { retry: SENDGRID_POLICY.retry },
+      );
       await this.emailOutboxRepository.updateStatus(outboxId, {
         status: 'SENT',
         attempts: job.attemptsMade + 1,

--- a/src/notification/services/notification.service.ts
+++ b/src/notification/services/notification.service.ts
@@ -16,6 +16,9 @@ import {
 } from '../../common/repositories/notification.repository';
 import { TransactionClient } from '../../common/repositories/repository.interface';
 import { getCorrelationId } from '../../common/tracing/tracing-context';
+import { createCircuitBreaker, CircuitBreaker } from '../../common/resilience/circuit-breaker';
+import { withResilience } from '../../common/resilience/resilience';
+import { BULL_QUEUE_POLICY } from '../../common/resilience/resilience.constants';
 
 /**
  * Everything `prepareNotification` produced that still needs to happen after
@@ -38,6 +41,17 @@ export interface PreparedNotification {
 @Injectable()
 export class NotificationService {
   private readonly logger = new Logger(NotificationService.name);
+
+  /**
+   * Circuit breaker for Redis-backed Bull enqueues (email + push). When Redis
+   * degrades, dispatch fails fast (and stays best-effort) rather than hanging
+   * the business operation that already committed — e.g. an insurance purchase
+   * or claim assessment that calls this after its transaction commits.
+   */
+  private readonly queueBreaker: CircuitBreaker = createCircuitBreaker(
+    BULL_QUEUE_POLICY.circuitBreaker.name,
+    BULL_QUEUE_POLICY.circuitBreaker,
+  );
 
   constructor(
     private readonly notificationRepository: NotificationRepository,
@@ -136,19 +150,33 @@ export class NotificationService {
     for (const item of items) {
       if (item.email) {
         try {
-          await this.emailQueue.add(
+          await withResilience<void>(
+            this.queueBreaker,
+            () =>
+              this.emailQueue.add(
+                {
+                  outboxId: item.email.outboxId,
+                  to: item.email.to,
+                  subject: item.email.subject,
+                  html: item.email.html,
+                  correlationId: getCorrelationId(),
+                },
+                {
+                  attempts: 5,
+                  backoff: { type: 'exponential', delay: 5000 },
+                  removeOnComplete: true,
+                  removeOnFail: false,
+                },
+              ),
             {
-              outboxId: item.email.outboxId,
-              to: item.email.to,
-              subject: item.email.subject,
-              html: item.email.html,
-              correlationId: getCorrelationId(),
-            },
-            {
-              attempts: 5,
-              backoff: { type: 'exponential', delay: 5000 },
-              removeOnComplete: true,
-              removeOnFail: false,
+              retry: BULL_QUEUE_POLICY.retry,
+              // Fail fast when Redis is degraded — the durable EmailOutbox row
+              // is still picked up by EmailRetryTask later.
+              fallback: () => {
+                this.logger.error(
+                  `Email queue is degraded (circuit open) — outbox ${item.email.outboxId} deferred to EmailRetryTask`,
+                );
+              },
             },
           );
         } catch (error) {
@@ -159,13 +187,25 @@ export class NotificationService {
 
       if (item.push) {
         try {
-          await this.pushQueue.add(
+          await withResilience<void>(
+            this.queueBreaker,
+            () =>
+              this.pushQueue.add(
+                {
+                  subscription: item.push.subscription,
+                  payload: item.push.payload,
+                  correlationId: getCorrelationId(),
+                },
+                { attempts: 5, backoff: { type: 'exponential', delay: 5000 } },
+              ),
             {
-              subscription: item.push.subscription,
-              payload: item.push.payload,
-              correlationId: getCorrelationId(),
+              retry: BULL_QUEUE_POLICY.retry,
+              fallback: () => {
+                this.logger.error(
+                  'Push queue is degraded (circuit open) — push notification skipped',
+                );
+              },
             },
-            { attempts: 5, backoff: { type: 'exponential', delay: 5000 } },
           );
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);

--- a/src/notification/services/notification.service.ts
+++ b/src/notification/services/notification.service.ts
@@ -150,10 +150,10 @@ export class NotificationService {
     for (const item of items) {
       if (item.email) {
         try {
-          await withResilience<void>(
+          await withResilience(
             this.queueBreaker,
-            () =>
-              this.emailQueue.add(
+            async () => {
+              await this.emailQueue.add(
                 {
                   outboxId: item.email.outboxId,
                   to: item.email.to,
@@ -167,7 +167,8 @@ export class NotificationService {
                   removeOnComplete: true,
                   removeOnFail: false,
                 },
-              ),
+              );
+            },
             {
               retry: BULL_QUEUE_POLICY.retry,
               // Fail fast when Redis is degraded — the durable EmailOutbox row
@@ -187,17 +188,18 @@ export class NotificationService {
 
       if (item.push) {
         try {
-          await withResilience<void>(
+          await withResilience(
             this.queueBreaker,
-            () =>
-              this.pushQueue.add(
+            async () => {
+              await this.pushQueue.add(
                 {
                   subscription: item.push.subscription,
                   payload: item.push.payload,
                   correlationId: getCorrelationId(),
                 },
                 { attempts: 5, backoff: { type: 'exponential', delay: 5000 } },
-              ),
+              );
+            },
             {
               retry: BULL_QUEUE_POLICY.retry,
               fallback: () => {

--- a/src/notification/services/web-push.service.spec.ts
+++ b/src/notification/services/web-push.service.spec.ts
@@ -1,12 +1,36 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { WebPushService } from './web-push.service';
+import { ConfigService } from '@nestjs/config';
+
+jest.mock('web-push', () => ({
+  setVapidDetails: jest.fn(),
+  sendNotification: jest.fn(),
+}));
 
 describe('WebPushService', () => {
   let service: WebPushService;
+  const webpushMock = jest.requireMock('web-push') as {
+    sendNotification: jest.Mock;
+    setVapidDetails: jest.Mock;
+  };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     const module: TestingModule = await Test.createTestingModule({
-      providers: [WebPushService],
+      providers: [
+        WebPushService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'notification.vapid.publicKey') return 'test-public';
+              if (key === 'notification.vapid.privateKey') return 'test-private';
+              if (key === 'notification.vapid.subjectEmail') return 'admin@test.com';
+              return undefined;
+            }),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<WebPushService>(WebPushService);
@@ -14,5 +38,64 @@ describe('WebPushService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('chaos — web-push provider outage', () => {
+    const job = {
+      data: {
+        subscription: { endpoint: 'https://push.example.com/abc', keys: {} },
+        payload: { title: 't', body: 'b' },
+      },
+    };
+
+    it('rethrows non-410 failures so Bull can retry with backoff', async () => {
+      webpushMock.sendNotification.mockRejectedValue(
+        new Error('push provider down'),
+      );
+
+      await expect(service.handlePushJob(job as any)).rejects.toThrow(
+        'push provider down',
+      );
+      // WEB_PUSH_POLICY: 2 attempts per delivery.
+      expect(webpushMock.sendNotification).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips expired subscriptions (HTTP 410) without retrying', async () => {
+      const expired = Object.assign(new Error('subscription gone'), {
+        statusCode: 410,
+      });
+      webpushMock.sendNotification.mockRejectedValue(expired);
+
+      await expect(service.handlePushJob(job as any)).resolves.toBeUndefined();
+      expect(webpushMock.sendNotification).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails fast once the circuit is open', async () => {
+      webpushMock.sendNotification.mockRejectedValue(
+        new Error('push provider down'),
+      );
+
+      let openError: unknown;
+      for (let i = 0; i < 10 && !openError; i++) {
+        try {
+          await service.handlePushJob({
+            ...job,
+            data: {
+              ...job.data,
+              subscription: {
+                endpoint: `https://push.example.com/${i}`,
+                keys: {},
+              },
+            },
+          } as any);
+        } catch (error) {
+          if ((error as { code?: string })?.code === 'EOPENBREAKER') {
+            openError = error;
+          }
+        }
+      }
+
+      expect(openError).toBeDefined();
+    });
   });
 });

--- a/src/notification/services/web-push.service.ts
+++ b/src/notification/services/web-push.service.ts
@@ -6,6 +6,9 @@ import { randomUUID } from 'crypto';
 import { QUEUE_NAMES, PushJobData } from '../constants/queue.constants';
 import { ConfigService } from '@nestjs/config';
 import { runWithTracingContext } from '../../common/tracing/tracing-context';
+import { createCircuitBreaker, CircuitBreaker } from '../../common/resilience/circuit-breaker';
+import { withResilience } from '../../common/resilience/resilience';
+import { WEB_PUSH_POLICY } from '../../common/resilience/resilience.constants';
 
 export interface WebPushPayload {
   title: string;
@@ -19,6 +22,16 @@ export class WebPushService {
   private readonly logger = new Logger(WebPushService.name);
 
   private readonly publicKey: string;
+
+  /**
+   * Circuit breaker + retry for VAPID web-push delivery. Expired subscriptions
+   * (410) still stop retrying immediately; other failures trip the breaker so
+   * the worker fails fast and lets Bull back off.
+   */
+  private readonly pushBreaker: CircuitBreaker = createCircuitBreaker(
+    WEB_PUSH_POLICY.circuitBreaker.name,
+    WEB_PUSH_POLICY.circuitBreaker,
+  );
 
   constructor(private readonly configService: ConfigService) {
     this.publicKey = this.configService.get<string>('notification.vapid.publicKey') || '';
@@ -60,7 +73,18 @@ export class WebPushService {
     }
 
     try {
-      await webpush.sendNotification(subscription, JSON.stringify(payload));
+      await withResilience(
+        this.pushBreaker,
+        () => webpush.sendNotification(subscription, JSON.stringify(payload)),
+        {
+          retry: {
+            ...WEB_PUSH_POLICY.retry,
+            // HTTP 410 = subscription no longer valid; never retry those.
+            retryIf: (error) =>
+              (error as { statusCode?: number })?.statusCode !== 410,
+          },
+        },
+      );
       this.logger.log(
         `Push notification sent to endpoint: ${subscription.endpoint}`,
       );

--- a/src/storage/storage.service.spec.ts
+++ b/src/storage/storage.service.spec.ts
@@ -1,0 +1,139 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StorageService } from './storage.service';
+import { ConfigService } from '@nestjs/config';
+import { getQueueToken } from '@nestjs/bull';
+import { QUEUE_NAMES } from '../notification/constants/queue.constants';
+import {
+  InternalServerErrorException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+
+describe('StorageService', () => {
+  let service: StorageService;
+
+  const config = {
+    get: jest.fn((key: string) => {
+      switch (key) {
+        case 'storage.ipfs.host':
+          return 'localhost';
+        case 'storage.ipfs.port':
+          return 5001;
+        case 'storage.ipfs.protocol':
+          return 'http';
+        case 'AWS_REGION':
+          return 'us-east-1';
+        case 'AWS_ACCESS_KEY_ID':
+          return 'test-key';
+        case 'AWS_SECRET_ACCESS_KEY':
+          return 'test-secret';
+        case 'AWS_S3_BUCKET':
+          return 'test-bucket';
+        default:
+          return undefined;
+      }
+    }),
+  };
+
+  const queue = { add: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StorageService,
+        { provide: ConfigService, useValue: config },
+        { provide: getQueueToken(QUEUE_NAMES.IPFS_PIN), useValue: queue },
+      ],
+    }).compile();
+
+    service = module.get<StorageService>(StorageService);
+  });
+
+  const file = (overrides: Record<string, unknown> = {}) =>
+    ({
+      fieldname: 'file',
+      originalname: 'photo.jpg',
+      encoding: '7bit',
+      mimetype: 'image/jpeg',
+      size: 1024,
+      buffer: Buffer.from('jpeg-data'),
+      stream: null,
+      destination: '',
+      filename: '',
+      path: '',
+      ...overrides,
+    }) as Express.Multer.File;
+
+  describe('chaos — AWS S3 outage', () => {
+    it('retries transient failures then surfaces an InternalServerErrorException', async () => {
+      (service as any).s3 = {
+        send: jest.fn().mockRejectedValue(new Error('s3 down')),
+      };
+
+      await expect(service.uploadFile(file())).rejects.toThrow(
+        InternalServerErrorException,
+      );
+      // AWS_S3_POLICY: 3 attempts per upload.
+      expect((service as any).s3.send).toHaveBeenCalledTimes(3);
+    });
+
+    it('stops calling S3 once the circuit is open (fail fast)', async () => {
+      (service as any).s3 = {
+        send: jest.fn().mockRejectedValue(new Error('s3 down')),
+      };
+
+      // Drive enough failures to trip the breaker (volumeThreshold 5).
+      for (let i = 0; i < 3; i++) {
+        await expect(service.uploadFile(file())).rejects.toThrow(
+          InternalServerErrorException,
+        );
+      }
+      const callsAfterTrips = (service as any).s3.send.mock.calls.length;
+
+      // Once open, further uploads must not hit S3 at all.
+      await expect(service.uploadFile(file())).rejects.toThrow(
+        InternalServerErrorException,
+      );
+      expect((service as any).s3.send.mock.calls.length).toBe(callsAfterTrips);
+    });
+  });
+
+  describe('chaos — IPFS outage', () => {
+    it('retries pin failures then surfaces ServiceUnavailableException', async () => {
+      (service as any).ipfs = {
+        add: jest.fn().mockRejectedValue(new Error('ipfs down')),
+        cat: jest.fn(),
+      };
+
+      await expect(
+        service.pinProjectMetadata({ projectId: 'p1' }),
+      ).rejects.toThrow(ServiceUnavailableException);
+      // IPFS_POLICY: 2 attempts per pin.
+      expect((service as any).ipfs.add).toHaveBeenCalledTimes(2);
+    });
+
+    it('verifies an IPFS hash through the breaker', async () => {
+      (service as any).ipfs = {
+        add: jest.fn(),
+        cat: jest.fn(async function* () {
+          yield Buffer.from('chunk');
+        }),
+      };
+
+      await expect(service.verifyIPFSHash('QmHash')).resolves.toBe(true);
+      expect((service as any).ipfs.cat).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('chaos — Bull queue (Redis) outage', () => {
+    it('retries the enqueue and rethrows when Redis is down', async () => {
+      queue.add.mockRejectedValue(new Error('redis down'));
+
+      await expect(
+        service.queuePinProjectMetadata({ projectId: 'p1' }),
+      ).rejects.toThrow('redis down');
+      // BULL_QUEUE_POLICY: 2 attempts per enqueue.
+      expect(queue.add).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -26,6 +26,13 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { QUEUE_NAMES, IpfsPinJobData } from '../notification/constants/queue.constants';
+import { createCircuitBreaker, CircuitBreaker } from '../common/resilience/circuit-breaker';
+import { withResilience } from '../common/resilience/resilience';
+import {
+  AWS_S3_POLICY,
+  IPFS_POLICY,
+  BULL_QUEUE_POLICY,
+} from '../common/resilience/resilience.constants';
 
 const ALLOWED_MIME_TYPES = new Set([
   'image/jpeg',
@@ -59,6 +66,24 @@ export class StorageService {
   private readonly s3: S3Client;
   private readonly bucket: string;
   private readonly maxFileSize: number;
+
+  /** Circuit breaker + retry for every AWS S3 operation. */
+  private readonly s3Breaker: CircuitBreaker = createCircuitBreaker(
+    AWS_S3_POLICY.circuitBreaker.name,
+    AWS_S3_POLICY.circuitBreaker,
+  );
+
+  /** Circuit breaker + retry for IPFS pin/read operations. */
+  private readonly ipfsBreaker: CircuitBreaker = createCircuitBreaker(
+    IPFS_POLICY.circuitBreaker.name,
+    IPFS_POLICY.circuitBreaker,
+  );
+
+  /** Circuit breaker for Redis-backed Bull queue enqueues. */
+  private readonly queueBreaker: CircuitBreaker = createCircuitBreaker(
+    BULL_QUEUE_POLICY.circuitBreaker.name,
+    BULL_QUEUE_POLICY.circuitBreaker,
+  );
 
   constructor(
     private readonly config: ConfigService,
@@ -147,7 +172,11 @@ export class StorageService {
         ContentType: file.mimetype,
         ContentLength: file.size,
       });
-      const result: PutObjectCommandOutput = await this.s3.send(command);
+      const result: PutObjectCommandOutput = await withResilience(
+        this.s3Breaker,
+        () => this.s3.send(command),
+        { retry: AWS_S3_POLICY.retry },
+      );
       this.logger.log(`Uploaded file to s3://${this.bucket}/${key} (ETag: ${result.ETag})`);
 
       const url = `https://${this.bucket}.s3.${this.config.get<string>('AWS_REGION')}.amazonaws.com/${key}`;
@@ -161,7 +190,11 @@ export class StorageService {
   async getPresignedUrl(key: string, expiresIn: number = DEFAULT_PRESIGN_EXPIRY): Promise<string> {
     try {
       const command = new PutObjectCommand({ Bucket: this.bucket, Key: key });
-      const url = await getSignedUrl(this.s3, command, { expiresIn });
+      const url = await withResilience(
+        this.s3Breaker,
+        () => getSignedUrl(this.s3, command, { expiresIn }),
+        { retry: AWS_S3_POLICY.retry },
+      );
       this.logger.log(`Generated presigned URL for key "${key}" (expires in ${expiresIn}s)`);
       return url;
     } catch (error) {
@@ -173,7 +206,11 @@ export class StorageService {
   async deleteObject(key: string): Promise<void> {
     try {
       const command = new DeleteObjectCommand({ Bucket: this.bucket, Key: key });
-      await this.s3.send(command);
+      await withResilience(
+        this.s3Breaker,
+        () => this.s3.send(command),
+        { retry: AWS_S3_POLICY.retry },
+      );
       this.logger.log(`Deleted object s3://${this.bucket}/${key}`);
     } catch (error) {
       this.logger.error(`Failed to delete object "${key}"`, error);
@@ -188,14 +225,19 @@ export class StorageService {
   async queuePinProjectMetadata(
     metadata: Record<string, unknown>,
   ): Promise<void> {
-    await this.ipfsPinQueue.add(
-      { metadata },
-      {
-        attempts: 5,
-        backoff: { type: 'exponential', delay: 5000 },
-        removeOnComplete: true,
-        removeOnFail: false,
-      },
+    await withResilience(
+      this.queueBreaker,
+      () =>
+        this.ipfsPinQueue.add(
+          { metadata },
+          {
+            attempts: 5,
+            backoff: { type: 'exponential', delay: 5000 },
+            removeOnComplete: true,
+            removeOnFail: false,
+          },
+        ),
+      { retry: BULL_QUEUE_POLICY.retry },
     );
     this.logger.log('Queued IPFS pin job for project metadata');
   }
@@ -203,7 +245,11 @@ export class StorageService {
   async pinProjectMetadata(metadata: Record<string, unknown>): Promise<string> {
     try {
       const ipfs = await this.getIpfs();
-      const cid = await ipfs.add(JSON.stringify(metadata));
+      const cid = await withResilience(
+        this.ipfsBreaker,
+        () => ipfs.add(JSON.stringify(metadata)),
+        { retry: IPFS_POLICY.retry },
+      );
       this.logger.log(`Pinned metadata with CID: ${cid.path}`);
       return cid.path;
     } catch (error) {
@@ -255,11 +301,17 @@ export class StorageService {
   async verifyIPFSHash(hash: string): Promise<boolean> {
     try {
       const ipfs = await this.getIpfs();
-      const chunks = [];
-      for await (const chunk of ipfs.cat(hash)) {
-        chunks.push(chunk);
-      }
-      return chunks.length > 0;
+      return withResilience(
+        this.ipfsBreaker,
+        async () => {
+          const chunks: unknown[] = [];
+          for await (const chunk of ipfs.cat(hash)) {
+            chunks.push(chunk);
+          }
+          return chunks.length > 0;
+        },
+        { retry: IPFS_POLICY.retry },
+      );
     } catch (error) {
       this.logger.warn(`IPFS hash verification failed for ${hash}`, error);
       return false;


### PR DESCRIPTION
implemented Consistent Circuit Breaker and Retry Patterns for External Service Calls
closes #460 

Shared resilience utilities (src/common/resilience/) — one standard pattern, backed by opossum (already a dependency):

circuit-breaker.ts — createCircuitBreaker(name, options) factory with sensible defaults (50% error threshold, 30s reset, volume threshold 5, per-request timeout) plus isCircuitOpenError().
retry.ts — withRetry() with exponential backoff, optional jitter, retryIf/onRetry hooks.
resilience.ts — withResilience() combining all three: retry on non-open failures, fail fast + optional fallback when the circuit is open.
resilience.constants.ts — one policy preset per dependency (Stellar RPC, S3, IPFS, SendGrid, web-push, Redis nonce, Bull queue, idempotency DB).
Every external client now wrapped:

Stellar RPC (indexer.service.ts) — getHealth, getLatestLedger, getEvents go through the breaker; the ad-hoc fetchEventsWithRetry loop was replaced (retry logging preserved via onRetry); stale INDEXER_RETRY_* config removed.
S3 (storage.service.ts) — upload, presign, delete; IPFS — pin + hash verification; Bull queue — pin enqueue.
SendGrid (email.service.ts), web-push (web-push.service.ts) — with the 410 expired-subscription case excluded from retries.
Redis nonce (nonce.service.ts) — set/get/del.
Notification dispatch (notification.service.ts) — the Bull enqueue path that insurance purchases/claim flows hit, with a circuit-open fallback that defers emails to the existing retry task.
Idempotency (idempotency.service.ts) — migrated to the shared breaker; the old custom CircuitBreaker is now a compatibility shim.