### PR TITLE
feat: implement JWT-based authentication flow with nonce validation i…

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Post, Body, HttpCode, HttpStatus, UnauthorizedException, BadRequestException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { Public } from './decorators/public.decorator';
+
+@ApiTags('Auth')
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Public()
+  @Post('login')
+  @HttpCode(HttpStatus.CREATED) // e2e tests expect 201 Created
+  @ApiOperation({ summary: 'Login with userId and a valid nonce' })
+  @ApiBody({ type: LoginDto })
+  @ApiResponse({ status: 201, description: 'Successfully authenticated, returns JWT token' })
+  @ApiResponse({ status: 400, description: 'Invalid or used nonce' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async login(@Body() loginDto: LoginDto) {
+    try {
+      return await this.authService.validateUserAndLogin(loginDto);
+    } catch (error) {
+      if (error instanceof BadRequestException || error.status === HttpStatus.BAD_REQUEST || error.name === 'BadRequestException') {
+        throw new UnauthorizedException(error.message);
+      }
+      throw error;
+    }
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -5,10 +5,14 @@ import { PassportModule } from '@nestjs/passport';
 import type { StringValue } from 'ms';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { UserModule } from '../user/user.module';
+import { NonceModule } from '../nonce/nonce.module';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
 
 @Module({
   imports: [
     UserModule,
+    NonceModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       imports: [ConfigModule],
@@ -39,7 +43,8 @@ import { UserModule } from '../user/user.module';
       },
     }),
   ],
-  providers: [JwtStrategy],
-  exports: [PassportModule, JwtModule],
+  controllers: [AuthController],
+  providers: [JwtStrategy, AuthService],
+  exports: [PassportModule, JwtModule, AuthService],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { UserService } from '../user/user.service';
+import { NonceService } from '../nonce/nonce.service';
+import { LoginDto } from './dto/login.dto';
+
+@Injectable()
+export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
+  constructor(
+    private readonly userService: UserService,
+    private readonly nonceService: NonceService,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  async validateUserAndLogin(loginDto: LoginDto) {
+    const { userId, nonce } = loginDto;
+
+    // Validate the nonce (throws BadRequestException if invalid/used)
+    await this.nonceService.consumeNonce(nonce);
+
+    // Ensure the user exists
+    let user;
+    try {
+      user = await this.userService.findById(userId);
+    } catch (error) {
+      this.logger.warn(`Login attempt for non-existent user: ${userId}`);
+      throw new UnauthorizedException('Invalid user');
+    }
+
+    // Generate JWT token
+    const payload = { sub: user.id };
+    return {
+      access_token: this.jwtService.sign(payload),
+    };
+  }
+}

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class LoginDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  nonce: string;
+}

--- a/src/storage/ipfs-pin.processor.ts
+++ b/src/storage/ipfs-pin.processor.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Process, Processor } from '@nestjs/bull';
 import { Job } from 'bull';
 import { StorageService } from './storage.service';
-import { IpfsPinJobData, QUEUE_NAMES } from 'src/notification/constants/queue.constants';
+import { IpfsPinJobData, QUEUE_NAMES } from '../notification/constants/queue.constants';
 
 @Injectable()
 @Processor(QUEUE_NAMES.IPFS_PIN)

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,7 +1,7 @@
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from '../src/app.module';
 import { PrismaService } from '../src/prisma.service';
 import { AuthService } from '../src/auth/auth.service';
@@ -41,7 +41,7 @@ describe('AuthController (e2e)', () => {
 
   describe('/auth/login (POST)', () => {
     it('should return a JWT token for a valid user and nonce', async () => {
-      const nonce = await nonceService.createNonce(userId);
+      const nonce = await nonceService.generateNonce();
       const loginDto = {
         userId,
         nonce,
@@ -68,7 +68,7 @@ describe('AuthController (e2e)', () => {
     });
 
     it('should reject a login attempt with a used nonce', async () => {
-      const nonce = await nonceService.createNonce(userId);
+      const nonce = await nonceService.generateNonce();
       const loginDto = {
         userId,
         nonce,


### PR DESCRIPTION
Closes  #462 

# Pull Request Documentation

## Title
Fix #462: Implement Missing Authentication Service and Login Flow

## Description
This PR addresses issue #462 by implementing the missing `AuthService` and `AuthController` and fixing the broken authentication pipeline.

Previously, the application was missing a centralized entry point to authenticate users, generate JWTs, and handle nonce verification. This gap caused broken dependencies in `JwtStrategy` and blocked successful E2E test runs.

### Changes Included
- **[NEW] `LoginDto`**: Created a DTO to validate the incoming `userId` and `nonce` payload for the `/auth/login` endpoint.
- **[NEW] `AuthService`**: Created the core authentication service responsible for verifying user nonces through the `NonceService`, checking user existence via `UserService`, and securely generating a `JWT` token.
- **[NEW] `AuthController`**: Created the REST controller exposing the `POST /auth/login` endpoint and mapped the corresponding swagger definitions. The endpoint is decorated with `@Public()` to bypass the global JWT guard.
- **[MODIFIED] `AuthModule`**: Wired up `AuthService`, `AuthController`, and `NonceModule` so all dependencies resolve successfully during application bootstrap.
- **[MODIFIED] E2E Tests**: Updated the e2e test suite (`test/auth.e2e-spec.ts`) to call `nonceService.generateNonce()` instead of the non-existent `createNonce` method, and fixed `supertest` namespace import issues.
- **[MODIFIED] `ipfs-pin.processor.ts`**: Fixed an absolute import that broke the test runner.
- **[TEST CONFIG]**: Bootstrapped `.env` with a strong `JWT_SECRET` and correct URLs to satisfy `class-validator` restrictions and pass the NestJS configuration checks.

## Verification
- Verified that all unit and E2E tests for `AuthController` pass successfully.
- Manually confirmed that passing a valid nonce retrieves an `access_token`, while passing an invalid or reused nonce strictly returns a `401 Unauthorized`.

## Related Issues
Closes #462
