### PR TITLE
fix(schema): standardize all model IDs to uuid() strategy

### DIFF
--- a/prisma/migrations/20260819000000_standardize_uuid/migration.sql
+++ b/prisma/migrations/20260819000000_standardize_uuid/migration.sql
@@ -1,0 +1,20 @@
+-- Migration: Standardize all ID columns to use UUID v4
+-- Existing rows retain their current ID values; only the DEFAULT changes.
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+ALTER TABLE "users"                 ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "projects"              ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "contributions"         ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "milestones"            ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "reputation_history"    ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "categories"            ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "refresh_tokens"        ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "ledger_cursors"        ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "processed_events"      ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "quarantined_events"    ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "indexer_logs"          ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "notification_settings" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "notifications"         ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "email_outbox"          ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "idempotency_keys"      ALTER COLUMN "id" SET DEFAULT gen_random_uuid();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ datasource db {
 // reputation, and notification workflows still depend on them.
 
 model User {
-  id              String    @id @default(cuid())
+  id              String    @id @default(uuid())
   walletAddress   String    @unique @map("wallet_address") // Public blockchain identifier
   profileData     Json?     @map("profile_data")
   reputationScore Int       @default(0) @map("reputation_score")
@@ -43,7 +43,7 @@ model User {
 }
 
 model Project {
-  id           String        @id @default(cuid())
+  id           String        @id @default(uuid())
   contractId   String        @unique @map("contract_id")
   creatorId    String        @map("creator_id")
   creator      User          @relation("ProjectCreator", fields: [creatorId], references: [id])
@@ -70,7 +70,7 @@ model Project {
 }
 
 model Contribution {
-  id              String    @id @default(cuid())
+  id              String    @id @default(uuid())
   transactionHash String    @unique @map("transaction_hash")
   investorId      String    @map("investor_id")
   investor        User      @relation(fields: [investorId], references: [id])
@@ -90,7 +90,7 @@ model Contribution {
 }
 
 model Milestone {
-  id             String          @id @default(cuid())
+  id             String          @id @default(uuid())
   projectId      String          @map("project_id")
   project        Project         @relation(fields: [projectId], references: [id])
   title          String
@@ -109,7 +109,7 @@ model Milestone {
 }
 
 model ReputationHistory {
-  id          String    @id @default(cuid())
+  id          String    @id @default(uuid())
   userId      String    @map("user_id")
   user        User      @relation(fields: [userId], references: [id])
   scoreChange Int       @map("score_change")
@@ -126,7 +126,7 @@ model ReputationHistory {
 }
 
 model Category {
-  id          String    @id @default(cuid())
+  id          String    @id @default(uuid())
   name        String    @unique
   description String?
   createdAt   DateTime  @default(now()) @map("created_at")
@@ -296,7 +296,7 @@ enum MilestoneStatus {
 }
 
 model RefreshToken {
-  id            String    @id @default(cuid())
+  id            String    @id @default(uuid())
   token         String    @unique
   userId        String    @map("user_id")
   user          User      @relation(fields: [userId], references: [id])
@@ -318,7 +318,7 @@ model RefreshToken {
 }
 
 model LedgerCursor {
-  id             String    @id @default(cuid())
+  id             String    @id @default(uuid())
   network        String    @unique
   lastLedgerSeq  Int       @map("last_ledger_seq")
   lastLedgerHash String?   @map("last_ledger_hash")
@@ -331,7 +331,7 @@ model LedgerCursor {
 }
 
 model ProcessedEvent {
-  id              String    @id @default(cuid())
+  id              String    @id @default(uuid())
   eventId         String    @unique @map("event_id")
   network         String
   ledgerSeq       Int       @map("ledger_seq")
@@ -348,7 +348,7 @@ model ProcessedEvent {
 }
 
 model QuarantinedEvent {
-  id              String   @id @default(cuid())
+  id              String   @id @default(uuid())
   eventId         String   @unique @map("event_id")
   network         String
   contractId      String   @map("contract_id")
@@ -367,7 +367,7 @@ model QuarantinedEvent {
 }
 
 model IndexerLog {
-  id        String    @id @default(cuid())
+  id        String    @id @default(uuid())
   level     String
   message   String
   metadata  Json?
@@ -382,7 +382,7 @@ model IndexerLog {
 }
 
 model NotificationSetting {
-  id                  String    @id @default(cuid())
+  id                  String    @id @default(uuid())
   userId              String    @unique @map("user_id")
   user                User      @relation(fields: [userId], references: [id])
   emailEnabled        Boolean   @default(true) @map("email_enabled")
@@ -399,7 +399,7 @@ model NotificationSetting {
 }
 
 model Notification {
-  id        String           @id @default(cuid())
+  id        String           @id @default(uuid())
   userId    String           @map("user_id")
   user      User             @relation(fields: [userId], references: [id])
   type      NotificationType
@@ -417,7 +417,7 @@ model Notification {
 }
 
 model EmailOutbox {
-  id        String      @id @default(cuid())
+  id        String      @id @default(uuid())
   to        String
   subject   String
   html      String
@@ -435,7 +435,7 @@ model EmailOutbox {
 }
 
 model IdempotencyKey {
-  id          String    @id @default(cuid())
+  id          String    @id @default(uuid())
   key         String    @unique
   method      String
   endpoint    String

--- a/src/auth/dto/wallet-login.dto.ts
+++ b/src/auth/dto/wallet-login.dto.ts
@@ -1,18 +1,19 @@
-import { IsString, IsNotEmpty, IsOptional, MaxLength } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, MaxLength, IsUUID } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class WalletLoginDto {
   @ApiProperty({
-    description: 'The user ID (wallet owner) to authenticate',
-    example: 'clxyz1234567890abcdef',
+    description: 'The user ID (UUID v4) of the wallet owner to authenticate',
+    example: '550e8400-e29b-41d4-a716-446655440000',
   })
   @IsString()
   @IsNotEmpty()
+  @IsUUID('4', { message: 'userId must be a valid UUID v4' })
   userId: string;
 
   @ApiProperty({
-    description: 'The one-time nonce obtained from POST /nonce',
-    example: 'a1b2c3d4e5f6...',
+    description: 'The one-time nonce obtained from POST /nonce/:userId',
+    example: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
   })
   @IsString()
   @IsNotEmpty()

--- a/src/common/dto/user-id-param.dto.ts
+++ b/src/common/dto/user-id-param.dto.ts
@@ -1,16 +1,14 @@
-import { IsString, IsNotEmpty, MaxLength, Matches } from 'class-validator';
+import { IsString, IsNotEmpty, MaxLength, IsUUID } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { sanitizeString } from '../utils/sanitization.util';
 
 export class UserIdParamDto {
   @IsString()
   @IsNotEmpty()
-  @MaxLength(64)
+  @MaxLength(36)
+  @IsUUID('4', { message: 'userId must be a valid UUID v4' })
   @Transform(({ value }) =>
     typeof value === 'string' ? sanitizeString(value) : value,
   )
-  @Matches(/^[a-zA-Z0-9]+$/, {
-    message: 'userId must be alphanumeric',
-  })
   userId: string;
 }

--- a/src/user/dto/user-params.dto.ts
+++ b/src/user/dto/user-params.dto.ts
@@ -1,21 +1,14 @@
-import { IsString, IsNotEmpty, MaxLength, Matches } from 'class-validator';
+import { IsString, IsNotEmpty, MaxLength, IsUUID } from 'class-validator';
 import { Transform } from 'class-transformer';
-import {
-  sanitizeString,
-  isValidCuid,
-} from '../../common/utils/sanitization.util';
+import { sanitizeString } from '../../common/utils/sanitization.util';
 
 export class UserParamsDto {
   @IsString()
   @IsNotEmpty()
-  @MaxLength(64)
-  @Transform(({ value }) => {
-    if (typeof value !== 'string') return value;
-    const sanitized = sanitizeString(value);
-    return sanitized;
-  })
-  @Matches(/^[a-zA-Z0-9]+$/, {
-    message: 'id must be alphanumeric (CUID format)',
-  })
+  @MaxLength(36)
+  @IsUUID('4', { message: 'id must be a valid UUID v4' })
+  @Transform(({ value }) =>
+    typeof value === 'string' ? sanitizeString(value) : value,
+  )
   id: string;
 }


### PR DESCRIPTION
## Summary

Resolves #468

### Changes
- Replace `cuid()` with `uuid()` across all 15 legacy Prisma models (User, Project, Contribution, Milestone, ReputationHistory, Category, RefreshToken, LedgerCursor, ProcessedEvent, QuarantinedEvent, IndexerLog, NotificationSetting, Notification, EmailOutbox, IdempotencyKey)
- Update `UserParamsDto` to accept UUID v4 format via `@IsUUID("4")` (hyphens now allowed)
- Update `UserIdParamDto` to accept UUID v4 format via `@IsUUID("4")`
- Update `WalletLoginDto` to validate `userId` as UUID v4
- Add migration SQL (`prisma/migrations/20260819000000_standardize_uuid/migration.sql`) to update column defaults on all legacy tables

### Why
Mixed cuid/uuid strategy leaks into DTO validation, repository generics, serialization utilities, and cross-domain joins. Standardizing to UUID v4 eliminates this inconsistency and aligns all models with the insurance domain models that already use uuid().

### Testing
- TypeScript compiles cleanly with `tsc --noEmit`
- User controller and service tests: all 15 pass