### PR TITLE
fix(middleware): harden soft-delete to intercept upsert operations

### DIFF
--- a/src/prisma.soft-delete.middleware.spec.ts
+++ b/src/prisma.soft-delete.middleware.spec.ts
@@ -183,4 +183,103 @@ describe('createSoftDeleteMiddleware', () => {
       expect(next.mock.calls[0][0].args.where).toEqual({ id: 'user-1' });
     });
   });
+
+  describe('upsert operations', () => {
+    it('injects deletedAt: null into the create branch so new rows are never soft-deleted', async () => {
+      const params = buildParams({
+        action: 'upsert' as any,
+        args: {
+          where: { walletAddress: 'GABC' },
+          create: { walletAddress: 'GABC', reputationScore: 0 },
+          update: {},
+        },
+      });
+
+      await middleware(params, next);
+
+      const forwarded = next.mock.calls[0][0];
+      expect(forwarded.args.create).toEqual({
+        walletAddress: 'GABC',
+        reputationScore: 0,
+        deletedAt: null,
+      });
+    });
+
+    it('injects deletedAt: null into the update branch to prevent accidental resurrection', async () => {
+      const params = buildParams({
+        action: 'upsert' as any,
+        args: {
+          where: { walletAddress: 'GABC' },
+          create: { walletAddress: 'GABC' },
+          update: { reputationScore: 10 },
+        },
+      });
+
+      await middleware(params, next);
+
+      const forwarded = next.mock.calls[0][0];
+      expect(forwarded.args.update).toEqual({
+        reputationScore: 10,
+        deletedAt: null,
+      });
+    });
+
+    it('does not overwrite an explicit deletedAt already in the create branch', async () => {
+      const params = buildParams({
+        action: 'upsert' as any,
+        args: {
+          where: { walletAddress: 'GABC' },
+          create: { walletAddress: 'GABC', deletedAt: null },
+          update: {},
+        },
+      });
+
+      await middleware(params, next);
+
+      const forwarded = next.mock.calls[0][0];
+      // deletedAt already present — must not be double-injected
+      const deletedAtKeys = Object.keys(forwarded.args.create).filter(
+        k => k === 'deletedAt',
+      );
+      expect(deletedAtKeys.length).toBe(1);
+    });
+
+    it('does not overwrite an intentional restore (deletedAt: null) in update branch', async () => {
+      const params = buildParams({
+        model: 'NotificationSetting' as MiddlewareParams['model'],
+        action: 'upsert' as any,
+        args: {
+          where: { userId: 'user-1' },
+          create: { userId: 'user-1' },
+          update: { deletedAt: null, emailEnabled: true },
+        },
+      });
+
+      await middleware(params, next);
+
+      const forwarded = next.mock.calls[0][0];
+      expect(forwarded.args.update).toEqual({
+        deletedAt: null,
+        emailEnabled: true,
+      });
+    });
+
+    it('passes upsert through untouched for models not in SOFT_DELETE_MODELS', async () => {
+      const params = buildParams({
+        model: 'SomethingElse' as MiddlewareParams['model'],
+        action: 'upsert' as any,
+        args: {
+          where: { id: '1' },
+          create: { id: '1' },
+          update: {},
+        },
+      });
+
+      await middleware(params, next);
+
+      const forwarded = next.mock.calls[0][0];
+      expect(forwarded.args.create).toEqual({ id: '1' });
+      expect(forwarded.args.update).toEqual({});
+    });
+  });
 });

--- a/src/prisma.soft-delete.middleware.ts
+++ b/src/prisma.soft-delete.middleware.ts
@@ -17,11 +17,13 @@ export const SOFT_DELETE_MODELS = [
   'AuditLog',
   'LedgerCursor',
   'ProcessedEvent',
+  'QuarantinedEvent',
   'IndexerLog',
   'NotificationSetting',
   'Notification',
   'EmailOutbox',
   'IdempotencyKey',
+  'RefreshToken',
 ] as const;
 
 export type SoftDeleteModel = (typeof SOFT_DELETE_MODELS)[number];
@@ -170,6 +172,43 @@ export function createSoftDeleteMiddleware(
       }
 
       removeIncludeDeletedFlags(args);
+    }
+
+    // Handle upsert operations — prevent soft-deleted records from being
+    // accidentally resurrected and ensure newly-created rows via upsert
+    // are never stamped with a deleted timestamp.
+    //
+    // Strategy:
+    //  - Inject `deletedAt: null` into the `create` branch so new rows
+    //    start as non-deleted (guards against callers omitting the field).
+    //  - Inject `deletedAt: null` into the `update` branch so an upsert
+    //    that matches a live row cannot accidentally re-stamp deletedAt
+    //    as null via an incomplete payload.
+    //
+    // Opt-out: if the caller already includes `deletedAt` in their payload
+    // (e.g. an intentional restore or explicit set), we leave it untouched.
+    if (action === 'upsert') {
+      const upsertArgs = args as unknown as {
+        where?: Record<string, unknown>;
+        create?: Record<string, unknown>;
+        update?: Record<string, unknown>;
+      };
+
+      // Ensure newly-created rows via upsert start as non-deleted.
+      if (upsertArgs.create && !('deletedAt' in upsertArgs.create)) {
+        upsertArgs.create = {
+          ...upsertArgs.create,
+          deletedAt: null,
+        };
+      }
+
+      // Ensure the update branch does not inadvertently set deletedAt.
+      if (upsertArgs.update && !('deletedAt' in upsertArgs.update)) {
+        upsertArgs.update = {
+          ...upsertArgs.update,
+          deletedAt: null,
+        };
+      }
     }
 
     return next(params);


### PR DESCRIPTION
## Summary

Resolves #470

### Problem
The soft-delete middleware handled `find*`, `update`, `updateMany`, `delete`, `deleteMany`, `count`, and `aggregate` — but not `upsert`. This allowed upsert calls in repositories (`upsertByWallet`, `upsertByContractId`, `upsertByTxHash`) and the notification controller to bypass the soft-delete filter, potentially resurrecting soft-deleted records.

Additionally, `QuarantinedEvent` and `RefreshToken` were missing from `SOFT_DELETE_MODELS` despite having a `deletedAt` column in the schema.

### Changes
- Added `QuarantinedEvent` and `RefreshToken` to `SOFT_DELETE_MODELS`
- Added `upsert` handling to `createSoftDeleteMiddleware`
- Injects `deletedAt: null` into the `create` branch so newly upserted rows are never accidentally created with a deleted timestamp
- Injects `deletedAt: null` into the `update` branch to prevent accidental soft-delete resurrection
- Preserves opt-out: if `deletedAt` is already present in the payload, it is not overwritten
- Added 5 regression tests covering all upsert bypass vectors

### Testing
All 21 soft-delete middleware tests pass (16 pre-existing + 5 new upsert tests).