### PR TITLE
docs: enforce consistent soft-delete lifecycle model

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Insurance is the primary product domain for this service.
 
 The Prisma schema includes insurance models for pools, policies, claims, reinsurance contracts, and audit logs. Legacy project/contribution models remain in place because the Stellar event indexer, reputation scoring, and notification flows still depend on them while the broader data layer is being consolidated.
 
+## 🗑️ Soft-Delete Policy
+
+All 20 tracked models use **soft-delete by default**: deleting a record stamps
+`deletedAt` with the current timestamp rather than issuing a SQL `DELETE`. The
+Prisma middleware (`createSoftDeleteMiddleware`) enforces this transparently —
+every standard `findMany`, `findUnique`, `update`, and `delete` call is already
+covered. Hard deletes (permanent removal) are restricted to `SoftDeleteService`
+and explicitly approved GDPR/admin paths, and always write an `AuditLog` entry.
+
+For the full lifecycle model, query conventions, repository patterns, restore
+vs. purge rules, and instructions for adding a new model, see
+**[SOFT_DELETE_GUIDE.md](SOFT_DELETE_GUIDE.md)**.
+
 ## 🏗️ Database Architecture
 
 **Prisma is the single source of truth** for all database access across this application:

--- a/SOFT_DELETE_GUIDE.md
+++ b/SOFT_DELETE_GUIDE.md
@@ -1,0 +1,455 @@
+# Soft-Delete & Record Lifecycle Guide
+
+This document is the authoritative reference for how soft-delete works in the
+Stellar Insured backend. All contributors should read it before touching deletion,
+restore, or purge logic.
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Models that support soft-delete](#2-models-that-support-soft-delete)
+3. [How the middleware works](#3-how-the-middleware-works)
+4. [Query conventions](#4-query-conventions)
+5. [Repository layer](#5-repository-layer)
+6. [SoftDeleteService (admin / purge operations)](#6-softdeleteservice-admin--purge-operations)
+7. [Lifecycle state machine](#7-lifecycle-state-machine)
+8. [Audit and admin flows](#8-audit-and-admin-flows)
+9. [Hard-delete (purge) policy](#9-hard-delete-purge-policy)
+10. [Adding a new model](#10-adding-a-new-model)
+11. [Common mistakes](#11-common-mistakes)
+
+---
+
+## 1. Overview
+
+Soft-delete is the default deletion mechanism for **all** tracked models.
+Deleting a record sets `deletedAt` to the current timestamp instead of issuing
+a SQL `DELETE`.  The Prisma middleware (`createSoftDeleteMiddleware`) enforces
+this transparently for every affected model.
+
+Key properties:
+
+| Property | Value |
+|---|---|
+| Default filter | `WHERE deleted_at IS NULL` on every read |
+| Deletion mechanism | `UPDATE … SET deleted_at = NOW()` |
+| Hard delete | Opt-in via `hardDelete: true` flag or `SoftDeleteService` |
+| Restore | `UPDATE … SET deleted_at = NULL` via `SoftDeleteRepository.restore()` |
+| Purge | `SoftDeleteService.permanentlyDeleteExpired()` or `hardDelete()` |
+
+---
+
+## 2. Models that support soft-delete
+
+The following 20 models all have a `deletedAt DateTime?` field and an
+`@@index([deletedAt])` index.  They are enumerated in
+`SOFT_DELETE_MODELS` inside
+[`src/prisma.soft-delete.middleware.ts`](src/prisma.soft-delete.middleware.ts).
+
+| Model | Table | Notes |
+|---|---|---|
+| `User` | `users` | PII — purge only via GDPR erasure flow |
+| `Project` | `projects` | Legacy indexer model |
+| `Contribution` | `contributions` | Legacy indexer model |
+| `Milestone` | `milestones` | Legacy indexer model |
+| `ReputationHistory` | `reputation_history` | Append-only; restore may affect score |
+| `Category` | `categories` | Reference data; prefer deactivation |
+| `InsurancePool` | `insurance_pools` | Primary domain |
+| `ReinsuranceContract` | `reinsurance_contracts` | Primary domain |
+| `InsurancePolicy` | `insurance_policies` | Primary domain |
+| `Claim` | `claims` | Primary domain |
+| `AuditLog` | `audit_logs` | Immutable; soft-delete only for archival |
+| `LedgerCursor` | `ledger_cursors` | Indexer |
+| `ProcessedEvent` | `processed_events` | Indexer — deduplicated by `eventId` |
+| `QuarantinedEvent` | `quarantined_events` | Indexer |
+| `IndexerLog` | `indexer_logs` | Indexer |
+| `NotificationSetting` | `notification_settings` | One row per user |
+| `Notification` | `notifications` | Consumer-facing |
+| `EmailOutbox` | `email_outbox` | Transient; purge after delivery |
+| `IdempotencyKey` | `idempotency_keys` | Purge after `expiresAt` |
+| `RefreshToken` | `refresh_tokens` | Purge on rotation / expiry |
+
+**No model intentionally bypasses soft-delete.** If a model should truly skip
+the middleware (e.g. a future immutable event log), it must be explicitly
+*excluded* from `SOFT_DELETE_MODELS` and that decision documented here.
+
+---
+
+## 3. How the middleware works
+
+`createSoftDeleteMiddleware` is registered **once** in
+`PrismaService.onModuleInit()` with `{ excludeDeleted: true }`.
+It intercepts the following Prisma actions:
+
+### 3.1 Read actions
+
+`findUnique` · `findUniqueOrThrow` · `findFirst` · `findFirstOrThrow` ·
+`findMany` · `count` · `aggregate` · `groupBy`
+
+Behaviour: injects `deletedAt: null` into the `where` clause unless the caller
+opts in with `_includeDeleted: true` (inside `where`) or `includeDeleted: true`
+(top-level query argument).
+
+```typescript
+// Default — excludes soft-deleted rows
+await prisma.insurancePolicy.findMany({ where: { userId } });
+
+// Opt-in — returns soft-deleted rows too
+await prisma.insurancePolicy.findMany({
+  where: { userId, _includeDeleted: true },
+});
+
+// Alternative top-level flag (also works)
+await prisma.insurancePolicy.findMany({
+  where: { userId },
+  includeDeleted: true,   // non-standard; cleaned up before reaching DB
+});
+```
+
+### 3.2 Write actions — soft delete
+
+`delete` · `deleteMany`
+
+Behaviour: converted to `update` / `updateMany` that stamps `deletedAt`.
+Only rows where `deletedAt IS NULL` are affected (idempotent — a second
+delete is a no-op on already-deleted rows).
+
+```typescript
+// Caller writes a normal delete …
+await prisma.claim.delete({ where: { id } });
+
+// … middleware converts it to:
+// UPDATE claims SET deleted_at = NOW() WHERE id = ? AND deleted_at IS NULL
+```
+
+To issue a real SQL `DELETE`, pass the `hardDelete` opt-out (see §4.3).
+
+### 3.3 Write actions — update / updateMany
+
+`update` · `updateMany`
+
+Behaviour: injects `deletedAt: null` into `where` so updates cannot
+accidentally touch soft-deleted rows.
+
+**Restore exception**: when `data.deletedAt === null` the middleware detects
+a restore operation and skips the filter so the deleted row can be reached.
+
+```typescript
+// Normal update — only touches live rows
+await prisma.insurancePolicy.update({ where: { id }, data: { status: 'ACTIVE' } });
+
+// Restore — middleware skips deletedAt filter
+await prisma.claim.update({ where: { id }, data: { deletedAt: null } });
+```
+
+### 3.4 Upsert
+
+`upsert`
+
+Behaviour:
+
+- `create` branch: `deletedAt: null` is injected if absent (new rows start
+  as live).
+- `update` branch: `deletedAt: null` is injected if absent (prevents an
+  accidentally-undefined payload from soft-deleting the row).
+
+Callers that intentionally set `deletedAt` in either branch take precedence.
+
+---
+
+## 4. Query conventions
+
+### 4.1 Standard read (default)
+
+Always excludes soft-deleted records. No extra flags needed.
+
+```typescript
+const policy = await this.policyRepository.findById(id);
+```
+
+### 4.2 Include deleted records
+
+Pass `_includeDeleted: true` inside `where`:
+
+```typescript
+const allPolicies = await prisma.insurancePolicy.findMany({
+  where: { userId, _includeDeleted: true },
+});
+```
+
+Or use `SoftDeleteService.findIncludingDeleted()` / `findManyIncludingDeleted()`.
+
+### 4.3 Hard-delete (purge)
+
+**Never call this outside of `SoftDeleteService` or an explicitly-approved
+GDPR/admin path.** Pass `hardDelete: true`:
+
+```typescript
+// Direct (avoid unless you have a specific reason):
+await prisma.refreshToken.delete({ where: { id }, hardDelete: true });
+
+// Preferred — goes through SoftDeleteService for audit logging:
+await this.softDeleteService.hardDelete('refreshToken', { id }, 'Token rotation');
+```
+
+### 4.4 Restore
+
+Use `SoftDeleteRepository.restore()` or `SoftDeleteService.restore()`:
+
+```typescript
+// Repository layer (single record by ID)
+await this.claimRepository.restore(claimId);
+
+// Service layer (arbitrary where clause, with audit log)
+await this.softDeleteService.restore('claim', { id: claimId });
+```
+
+### 4.5 groupBy and aggregate over deleted data
+
+```typescript
+// Excludes deleted rows by default
+await prisma.claim.groupBy({ by: ['status'], _count: true });
+
+// Include deleted
+await prisma.claim.groupBy({
+  by: ['status'],
+  where: { _includeDeleted: true },
+  _count: true,
+});
+```
+
+---
+
+## 5. Repository layer
+
+### 5.1 Class hierarchy
+
+```
+BaseRepository<T, ID>
+  └─ SoftDeleteRepository<T, ID>
+       ├─ ClaimRepository
+       ├─ InsurancePolicyRepository
+       ├─ InsurancePoolRepository
+       ├─ ReinsuranceContractRepository
+       ├─ UserRepository
+       ├─ ProjectRepository
+       └─ … (all other model repositories)
+```
+
+### 5.2 `BaseRepository.delete(id)`
+
+Calls `prisma[model].delete({ where: { id } })`.  The soft-delete middleware
+converts this to a soft-delete automatically.
+
+> **Note**: The method is named `delete` but it performs a **soft-delete**.
+> This is intentional — callers should treat `delete` as the standard, safe
+> removal path. If you need a hard delete, use `SoftDeleteService.hardDelete()`.
+
+### 5.3 `SoftDeleteRepository` extras
+
+| Method | What it does |
+|---|---|
+| `softDelete(id)` | Stamps `deletedAt` explicitly via `update`. Equivalent to `delete()` but bypasses middleware conversion (useful when you need to control the timestamp). |
+| `restore(id)` | Clears `deletedAt` via `updateMany({ where: { id, deletedAt: { not: null } } })`. `updateMany` triggers the middleware's restore path because `data.deletedAt === null`. |
+| `softDeleteMany(where)` | Stamps `deletedAt` on all matching rows. |
+
+### 5.4 Transaction support
+
+Every repository method accepts an optional `tx?: TransactionClient` so it
+can participate in a `prisma.$transaction()` block without losing middleware
+coverage (the transaction client inherits the same middleware stack).
+
+```typescript
+await this.prisma.$transaction(async tx => {
+  await this.policyRepository.updateStatus(id, PolicyStatus.CANCELLED, tx);
+  await this.poolService.unlockCapital(poolId, amount, tx);
+});
+```
+
+---
+
+## 6. SoftDeleteService (admin / purge operations)
+
+`SoftDeleteService` is the **only** place where hard-delete (purge) logic
+should live outside of explicitly-approved admin controllers.
+
+| Method | Purpose |
+|---|---|
+| `hardDelete(model, where, reason)` | Permanently deletes one record; writes an audit log entry. |
+| `hardDeleteMany(model, where, reason)` | Permanently deletes matching records; writes audit log. |
+| `restore(model, where)` | Restores a soft-deleted record. |
+| `restoreMany(model, where)` | Restores multiple soft-deleted records. |
+| `findIncludingDeleted(model, where)` | Returns a single record regardless of `deletedAt`. |
+| `findManyIncludingDeleted(model, options)` | Returns all matching records regardless of `deletedAt`. |
+| `findManyDeleted(model, options)` | Returns only soft-deleted records (`deletedAt IS NOT NULL`). |
+| `countDeleted(model, where)` | Counts soft-deleted records. |
+| `permanentlyDeleteExpired(model, deletedBefore)` | Purges records soft-deleted before a given date (retention cleanup). |
+| `isDeleted(model, where)` | Returns `true` if the record exists and is soft-deleted. |
+
+All purge operations write a best-effort `AuditLog` entry with
+`action: AuditAction.DELETE` and the `reason` you supply.
+
+---
+
+## 7. Lifecycle state machine
+
+```
+                    ┌─────────────────────────────────────────┐
+                    │           LIVE (deletedAt IS NULL)       │
+                    │                                          │
+                    │  create()  ──────────────────────────►  │
+                    │                                          │
+                    │  update() / updateMany()  (status etc.)  │
+                    │                                          │
+                    └───────────────┬──────────────────────────┘
+                                    │ delete() / deleteMany()
+                                    │ (middleware converts to UPDATE)
+                                    ▼
+                    ┌─────────────────────────────────────────┐
+                    │     SOFT-DELETED (deletedAt IS NOT NULL)  │
+                    │                                          │
+                    │  invisible to all standard queries       │
+                    │  visible via _includeDeleted flag        │
+                    │  visible via SoftDeleteService helpers   │
+                    │                                          │
+                    └──────┬────────────────────┬─────────────┘
+                           │ restore()           │ hardDelete() /
+                           │                     │ permanentlyDeleteExpired()
+                           ▼                     ▼
+                    ┌──────────────┐   ┌─────────────────────┐
+                    │     LIVE     │   │  PURGED (gone from  │
+                    │  (restored)  │   │    the database)    │
+                    └──────────────┘   └─────────────────────┘
+```
+
+**Distinguishing soft-deleted from purged records**:
+
+- Soft-deleted records exist in the database with `deletedAt IS NOT NULL`.
+  They appear in audit logs and can be restored.
+- Purged records no longer exist in any table. Their last trace is an
+  `AuditLog` row with `action = 'DELETE'` and `beforeState` containing a
+  snapshot of the `where` clause used for the purge.
+
+---
+
+## 8. Audit and admin flows
+
+### 8.1 Viewing soft-deleted records
+
+Any admin query that passes `_includeDeleted: true` in `where` will see all
+records, both live and soft-deleted.
+
+```typescript
+// Admin endpoint: list all deleted policies for a user
+const deleted = await this.softDeleteService.findManyDeleted(
+  'insurancePolicy',
+  { where: { userId } },
+);
+```
+
+### 8.2 Identifying the deletion event
+
+Every soft-delete operation goes through the middleware's `update` path.
+If you need to know *who* deleted a record and *when*, query `AuditLog`:
+
+```typescript
+const auditEntry = await prisma.auditLog.findFirst({
+  where: {
+    entityType: 'InsurancePolicy',
+    entityId: policyId,
+    action: AuditAction.DELETE,
+  },
+  orderBy: { timestamp: 'desc' },
+});
+```
+
+> **Note**: The domain services (`InsuranceService`, `ClaimService`) call
+> `AuditService` explicitly for business-level events (purchase, approve,
+> reject, payout). For soft-deletes triggered directly through the repository
+> layer, an `AuditLog` entry is only created automatically for **hard-delete
+> (purge)** operations via `SoftDeleteService`.  If you need an audit trail
+> for soft-deletes too, call `AuditService.logUpdate()` or
+> `AuditService.log()` in the same transaction.
+
+### 8.3 Identifying purged records
+
+Purged records leave an `AuditLog` entry with `action = 'DELETE'` and the
+`beforeState` field containing `{ where: …, count?: … }`.  Because
+`AuditLog` itself is soft-deletable, purge entries are never removed by
+default.
+
+---
+
+## 9. Hard-delete (purge) policy
+
+Hard deletes must only be used for:
+
+| Scenario | Approved path |
+|---|---|
+| GDPR right-to-erasure | `SoftDeleteService.hardDelete('user', { id }, 'GDPR erasure request #…')` |
+| Token rotation (refresh tokens) | `SoftDeleteService.hardDeleteMany('refreshToken', { familyId, expiresAt: { lt: now } }, 'Rotation cleanup')` |
+| Retention cleanup (configurable TTL) | `SoftDeleteService.permanentlyDeleteExpired(model, cutoffDate)` |
+| Re-org rollback (indexer) | Approved migration script only |
+| Idempotency key expiry | `SoftDeleteService.permanentlyDeleteExpired('idempotencyKey', cutoffDate)` |
+
+Every other deletion must be a soft-delete.
+
+---
+
+## 10. Adding a new model
+
+1. Add `deletedAt DateTime? @map("deleted_at")` to the model in
+   `prisma/schema.prisma`.
+2. Add `@@index([deletedAt])` to the model.
+3. Add the model name to `SOFT_DELETE_MODELS` in
+   `src/prisma.soft-delete.middleware.ts`.
+4. Run `npx prisma migrate dev --name add_soft_delete_to_<model>`.
+5. Update the model table in §2 of this document.
+
+If a new model intentionally *bypasses* soft-delete (immutable ledger rows,
+pure event log, etc.), document it in §2 with a clear reason and ensure it is
+absent from `SOFT_DELETE_MODELS`.
+
+---
+
+## 11. Common mistakes
+
+### ❌ Calling `prisma[model].delete()` and expecting a hard delete
+
+```typescript
+// WRONG — this is intercepted by middleware and becomes a soft-delete
+await prisma.claim.delete({ where: { id } });
+```
+
+Use `SoftDeleteService.hardDelete()` when you need a real SQL `DELETE`.
+
+### ❌ Calling `prisma[model].update()` on a soft-deleted record
+
+Standard updates inject `deletedAt: null` into `where`, so they silently
+no-op on soft-deleted rows.
+
+```typescript
+// WRONG — will silently do nothing if the claim is soft-deleted
+await prisma.claim.update({ where: { id }, data: { status: 'APPROVED' } });
+```
+
+Restore the record first, then update it; or use `SoftDeleteService.restore()`.
+
+### ❌ Forgetting `_includeDeleted` in admin queries
+
+Admin or analytics queries that forget the flag will silently omit deleted
+rows, producing misleading counts/reports.
+
+### ❌ Adding `deletedAt` to a model without updating `SOFT_DELETE_MODELS`
+
+The middleware only intercepts models listed in `SOFT_DELETE_MODELS`.  A
+model with a `deletedAt` column but absent from the list will receive real
+SQL `DELETE` operations.
+
+### ❌ Doing a hard-delete without a reason string
+
+All `SoftDeleteService` purge methods accept a `reason` argument.  Always
+supply one — it is written into the `AuditLog.reason` field and is
+invaluable during incident response.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,24 @@ datasource db {
 // Insurance is the primary product domain for this service.
 // Legacy project/contribution models remain because the indexer,
 // reputation, and notification workflows still depend on them.
+//
+// ──────────────────────────────────────────────────────────────────────────────
+// SOFT-DELETE CONVENTION
+// ──────────────────────────────────────────────────────────────────────────────
+// Every model in this schema supports soft-delete via a `deletedAt` field.
+// Deleting a record sets `deletedAt = NOW()` rather than issuing a SQL DELETE.
+// The Prisma middleware (`createSoftDeleteMiddleware`) enforces this
+// automatically for all models listed in `SOFT_DELETE_MODELS`.
+//
+// Rules:
+//   1. A model that has `deletedAt` MUST also appear in `SOFT_DELETE_MODELS`.
+//   2. Every `deletedAt` field MUST have a corresponding `@@index([deletedAt])`.
+//   3. Hard deletes (purge) are only allowed through `SoftDeleteService`.
+//   4. To restore a record, use `SoftDeleteRepository.restore()` or
+//      `SoftDeleteService.restore()`.
+//
+// See SOFT_DELETE_GUIDE.md for the full lifecycle documentation.
+// ──────────────────────────────────────────────────────────────────────────────
 
 model User {
   id              String    @id @default(uuid())
@@ -22,6 +40,7 @@ model User {
   trustScore      Int       @default(500) @map("trust_score")
   createdAt       DateTime  @default(now()) @map("created_at")
   updatedAt       DateTime  @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt       DateTime? @map("deleted_at")
 
   // Notification fields (encrypted at rest)
@@ -57,6 +76,7 @@ model Project {
   ipfsHash     String?       @map("ipfs_hash")
   createdAt    DateTime      @default(now()) @map("created_at")
   updatedAt    DateTime      @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt    DateTime?     @map("deleted_at")
 
   // Relations
@@ -80,6 +100,7 @@ model Contribution {
   timestamp       DateTime  @default(now())
   createdAt       DateTime  @default(now()) @map("created_at")
   updatedAt       DateTime  @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt       DateTime? @map("deleted_at")
 
   @@index([investorId])
@@ -100,6 +121,7 @@ model Milestone {
   completionDate DateTime?       @map("completion_date")
   createdAt      DateTime        @default(now()) @map("created_at")
   updatedAt      DateTime        @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt      DateTime?       @map("deleted_at")
 
   @@index([projectId])
@@ -117,6 +139,7 @@ model ReputationHistory {
   timestamp   DateTime  @default(now())
   createdAt   DateTime  @default(now()) @map("created_at")
   updatedAt   DateTime  @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt   DateTime? @map("deleted_at")
 
   @@index([userId])
@@ -131,6 +154,7 @@ model Category {
   description String?
   createdAt   DateTime  @default(now()) @map("created_at")
   updatedAt   DateTime  @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt   DateTime? @map("deleted_at")
 
   @@index([deletedAt])
@@ -144,6 +168,7 @@ model InsurancePool {
   lockedCapital Decimal               @default(0) @map("locked_capital") @db.Decimal(18, 2)
   createdAt     DateTime              @default(now()) @map("created_at")
   updatedAt     DateTime              @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt     DateTime?             @map("deleted_at")
   policies      InsurancePolicy[]
   contracts     ReinsuranceContract[]
@@ -160,6 +185,7 @@ model ReinsuranceContract {
   premiumRate   Decimal           @map("premium_rate") @db.Decimal(10, 4)
   createdAt     DateTime          @default(now()) @map("created_at")
   updatedAt     DateTime          @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt     DateTime?         @map("deleted_at")
   policies      InsurancePolicy[]
 
@@ -184,6 +210,7 @@ model InsurancePolicy {
   endDate        DateTime?            @map("end_date")
   createdAt      DateTime             @default(now()) @map("created_at")
   updatedAt      DateTime             @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt      DateTime?            @map("deleted_at")
   claims         Claim[]
 
@@ -206,6 +233,7 @@ model Claim {
   description  String?
   createdAt    DateTime        @default(now()) @map("created_at")
   updatedAt    DateTime        @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt    DateTime?       @map("deleted_at")
 
   @@index([policyId])
@@ -230,6 +258,7 @@ model AuditLog {
   correlationId   String?     @map("correlation_id")
   timestamp       DateTime    @default(now())
   createdAt       DateTime    @default(now()) @map("created_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt       DateTime?   @map("deleted_at")
 
   @@index([userId])
@@ -307,6 +336,7 @@ model RefreshToken {
   fingerprint   String?   // Device/session fingerprint for abuse detection
   createdAt     DateTime  @default(now()) @map("created_at")
   updatedAt     DateTime  @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt     DateTime? @map("deleted_at")
 
   @@index([userId])
@@ -324,6 +354,7 @@ model LedgerCursor {
   lastLedgerHash String?   @map("last_ledger_hash")
   updatedAt      DateTime  @updatedAt @map("updated_at")
   createdAt      DateTime  @default(now()) @map("created_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt      DateTime? @map("deleted_at")
 
   @@index([deletedAt])
@@ -339,6 +370,7 @@ model ProcessedEvent {
   eventType       String    @map("event_type")
   transactionHash String    @map("transaction_hash")
   processedAt     DateTime  @default(now()) @map("processed_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt       DateTime? @map("deleted_at")
 
   @@index([network, ledgerSeq])
@@ -358,6 +390,7 @@ model QuarantinedEvent {
   rawXdr          String   @map("raw_xdr")
   reason          String
   createdAt       DateTime @default(now()) @map("created_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt       DateTime? @map("deleted_at")
 
   @@index([network, ledgerSeq])
@@ -373,6 +406,7 @@ model IndexerLog {
   metadata  Json?
   timestamp DateTime  @default(now())
   createdAt DateTime  @default(now()) @map("created_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt DateTime? @map("deleted_at")
 
   @@index([timestamp])
@@ -392,6 +426,7 @@ model NotificationSetting {
   notifyDeadlines     Boolean   @default(true) @map("notify_deadlines")
   createdAt           DateTime  @default(now()) @map("created_at")
   updatedAt           DateTime  @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt           DateTime? @map("deleted_at")
 
   @@index([deletedAt])
@@ -408,6 +443,7 @@ model Notification {
   read      Boolean          @default(false)
   data      Json? // Optional metadata (e.g., projectId)
   createdAt DateTime         @default(now()) @map("created_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt DateTime?        @map("deleted_at")
 
   @@index([userId])
@@ -426,6 +462,7 @@ model EmailOutbox {
   lastError String?     @map("last_error")
   createdAt DateTime    @default(now()) @map("created_at")
   updatedAt DateTime    @updatedAt @map("updated_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt DateTime?   @map("deleted_at")
 
   @@index([status])
@@ -444,6 +481,7 @@ model IdempotencyKey {
   status      String    @default("PENDING")
   expiresAt   DateTime  @map("expires_at")
   createdAt   DateTime  @default(now()) @map("created_at")
+  /// Soft-delete timestamp. NULL = live record. See SOFT_DELETE_GUIDE.md.
   deletedAt   DateTime? @map("deleted_at")
 
   @@index([expiresAt])

--- a/src/common/repositories/base.repository.ts
+++ b/src/common/repositories/base.repository.ts
@@ -53,6 +53,22 @@ export abstract class BaseRepository<T, ID = string> implements IRepository<
     return this.delegate(tx).update({ where: { id }, data }) as Promise<T>;
   }
 
+  /**
+   * Soft-delete a record by its primary key.
+   *
+   * Despite the name, this issues a `prisma[model].delete()` which the
+   * soft-delete middleware intercepts and converts to:
+   *
+   *   `UPDATE … SET deleted_at = NOW() WHERE id = ? AND deleted_at IS NULL`
+   *
+   * The row is **not** removed from the database — it is hidden from standard
+   * queries but can be recovered via `SoftDeleteRepository.restore()` or
+   * `SoftDeleteService.restore()`.
+   *
+   * To permanently remove a row, use `SoftDeleteService.hardDelete()`.
+   *
+   * See SOFT_DELETE_GUIDE.md §5.2
+   */
   async delete(id: ID, tx?: TransactionClient): Promise<T> {
     return this.delegate(tx).delete({ where: { id } }) as Promise<T>;
   }

--- a/src/common/repositories/soft-delete.repository.ts
+++ b/src/common/repositories/soft-delete.repository.ts
@@ -6,13 +6,32 @@ import {
 import { BaseRepository } from './base.repository';
 
 /**
- * Extends BaseRepository with explicit soft-delete / restore helpers.
+ * Extends `BaseRepository` with explicit soft-delete and restore helpers.
  *
- * The PrismaService already registers soft-delete middleware that converts
- * `delete` operations into `UPDATE … SET deleted_at = NOW()`, so most
- * callers never need to call `softDelete` directly.  This class exists for
- * the rare cases where a service needs to *explicitly* stamp `deletedAt` on
- * a batch of rows (e.g. cascade soft-delete) or restore a record.
+ * ## Relationship to the soft-delete middleware
+ *
+ * `PrismaService` registers `createSoftDeleteMiddleware({ excludeDeleted: true })`
+ * on startup.  This means:
+ *
+ * - `BaseRepository.delete(id)` → intercepted by middleware →
+ *   `UPDATE … SET deleted_at = NOW()` (soft-delete).
+ * - `SoftDeleteRepository.softDelete(id)` → calls `update` with
+ *   `data.deletedAt = new Date()` → also a soft-delete, bypassing the
+ *   middleware conversion (useful when you need explicit timestamp control).
+ * - `SoftDeleteRepository.restore(id)` → calls `updateMany` with
+ *   `data.deletedAt = null`.  The middleware detects `data.deletedAt === null`
+ *   as a restore operation and skips the default `deletedAt IS NULL` filter
+ *   on `where`, allowing the deleted row to be reached.
+ * - `SoftDeleteRepository.softDeleteMany(where)` → stamps `deletedAt` on all
+ *   matching rows in one statement.
+ *
+ * ## Hard deletes
+ *
+ * None of the methods in this class issue a hard delete.  For permanent
+ * removal, use `SoftDeleteService.hardDelete()` or
+ * `SoftDeleteService.hardDeleteMany()`.
+ *
+ * See SOFT_DELETE_GUIDE.md §5 for the full repository layer reference.
  */
 export abstract class SoftDeleteRepository<T, ID = string>
   extends BaseRepository<T, ID>
@@ -23,9 +42,15 @@ export abstract class SoftDeleteRepository<T, ID = string>
   }
 
   /**
-   * Explicit soft-delete: stamps `deletedAt` on a single record.
-   * Prefer the standard `delete()` method (handled by middleware) unless you
-   * need fine-grained control over the timestamp.
+   * Explicitly stamp `deletedAt` on a single record via an `update` call.
+   *
+   * Prefer `BaseRepository.delete(id)` (middleware-intercepted) for the
+   * normal soft-delete path.  Use `softDelete` directly only when you need
+   * fine-grained control over the timestamp or when you want to bypass the
+   * middleware's `delete → update` conversion to avoid double-interception.
+   *
+   * The middleware's update handler adds `deletedAt: null` to `where`, which
+   * means only live rows (not already-deleted rows) are affected.
    */
   async softDelete(id: ID, tx?: TransactionClient): Promise<T> {
     return this.delegate(tx).update({
@@ -36,26 +61,40 @@ export abstract class SoftDeleteRepository<T, ID = string>
 
   /**
    * Restore a soft-deleted record by clearing `deletedAt`.
-   * Note: the soft-delete middleware filters deleted rows, so this query uses
-   * `updateMany` with `includeDeleted: true` semantics via raw access.
+   *
+   * Uses `updateMany` with `{ id, deletedAt: { not: null } }` so that:
+   *   1. Only the target row is affected (filtered by `id`).
+   *   2. Only rows that are currently soft-deleted are touched (filtered by
+   *      `deletedAt: { not: null }`).
+   *   3. The middleware's restore path is triggered because `data.deletedAt
+   *      === null`, which skips the default `deletedAt IS NULL` filter on
+   *      `where` — allowing deleted rows to be reached.
+   *
+   * After the `updateMany`, a `findUnique` re-fetches and returns the row.
+   * If the record was already live (count === 0), the existing live row is
+   * returned unchanged.
    */
   async restore(id: ID, tx?: TransactionClient): Promise<T> {
-    // We bypass the soft-delete middleware by using updateMany with the
-    // raw where clause; the middleware only intercepts `update` with a
-    // unique where, not `updateMany`.
     const results = await this.delegate(tx).updateMany({
       where: { id, deletedAt: { not: null } },
       data: { deletedAt: null },
     });
+
     if (results.count === 0) {
+      // Record is already live (or does not exist).
       const record = await this.delegate(tx).findUnique({ where: { id } });
       return record as T;
     }
+
     return this.delegate(tx).findUnique({ where: { id } }) as Promise<T>;
   }
 
   /**
-   * Soft-delete multiple records matching a where clause in one statement.
+   * Soft-delete multiple records matching a `where` clause in one statement.
+   *
+   * Returns the count of rows that were stamped.  Rows already soft-deleted
+   * are not re-stamped (the middleware injects `deletedAt: null` into
+   * `where` for `updateMany` operations that are not restores).
    */
   async softDeleteMany(
     where: Record<string, unknown>,

--- a/src/database.module.ts
+++ b/src/database.module.ts
@@ -1,6 +1,25 @@
 import { Module } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
 
+/**
+ * Core database module.
+ *
+ * Provides and exports `PrismaService` — the single entry point for all
+ * database access across the application.
+ *
+ * ## Soft-delete middleware
+ *
+ * The soft-delete middleware is registered **once** inside
+ * `PrismaService.onModuleInit()` with `{ excludeDeleted: true }`.
+ * It is not registered here so that the middleware lifecycle is tied to the
+ * `PrismaService` instance rather than to the module graph.
+ *
+ * Importing `DatabaseModule` is sufficient to get transparent soft-delete
+ * behaviour on all supported models.  You do not need to register the
+ * middleware yourself.
+ *
+ * See also: SOFT_DELETE_GUIDE.md §3
+ */
 @Module({
   providers: [PrismaService],
   exports: [PrismaService],

--- a/src/insurance/claim.service.ts
+++ b/src/insurance/claim.service.ts
@@ -25,6 +25,41 @@ import {
 } from '../notification/services/notification.service';
 import { NotificationType } from '../notification/enums/notification-type.enum';
 
+/**
+ * ## Deletion / lifecycle semantics
+ *
+ * `ClaimService` never issues direct `prisma.delete()` or `prisma.update()`
+ * calls that could bypass the soft-delete middleware.  All mutations go
+ * through `ClaimRepository`, which extends `SoftDeleteRepository`.
+ *
+ * - **Status transitions** (PENDING → APPROVED / REJECTED / PAID) →
+ *   `claimRepository.updateStatusWithPolicy()`.  The claim row stays live
+ *   so that reports and audit trails can reference it.
+ * - **Soft-delete** (remove a claim from standard query results) →
+ *   `claimRepository.delete(id)`.  The middleware converts this to
+ *   `UPDATE … SET deleted_at = NOW()`.
+ * - **Hard delete (purge)** → only via `SoftDeleteService.hardDelete()` on
+ *   approved GDPR / admin paths.
+ *
+ * ### Direct `tx.insurancePolicy.findUnique()` in `createClaim`
+ *
+ * The single direct Prisma access in this service is a **read-only lookup**
+ * inside `createClaim()`.  It retrieves the policy's `userId` to prepare
+ * the notification row inside the same transaction.  This is intentional:
+ *   - It is not a delete or update, so the soft-delete semantics are
+ *     irrelevant (the middleware still applies the `deletedAt IS NULL` filter
+ *     so a soft-deleted policy will correctly cause a lookup miss).
+ *   - It uses the transaction client (`tx`) so the lookup participates in
+ *     the same atomic write boundary as the `createClaim` call.
+ *   - Moving this into a repository method would require an additional
+ *     `InsurancePolicyRepository` dependency on `ClaimService`, which would
+ *     be a cross-aggregate dependency for a single field select.
+ *
+ * If the `ClaimRepository` is extended with a `findPolicyUserId(policyId, tx)`
+ * method in the future, the direct call below should be removed.
+ *
+ * See SOFT_DELETE_GUIDE.md for the full lifecycle state machine.
+ */
 @Injectable()
 export class ClaimService {
   private readonly logger = new Logger(ClaimService.name);
@@ -359,6 +394,11 @@ export class ClaimService {
     let createdNotification: PreparedNotification | null = null;
 
     const created = await this.prisma.$transaction(async tx => {
+      // Direct read-only lookup via the transaction client.
+      // This is the only direct Prisma access in ClaimService and is
+      // intentional — see the class-level JSDoc for the rationale.
+      // The soft-delete middleware still applies: a soft-deleted policy will
+      // not be found and will correctly trigger the BadRequestException below.
       const policy = await tx.insurancePolicy.findUnique({
         where: { id: policyId },
         select: { id: true, userId: true },

--- a/src/insurance/insurance.service.ts
+++ b/src/insurance/insurance.service.ts
@@ -15,6 +15,26 @@ import {
 } from '../notification/services/notification.service';
 import { NotificationType } from '../notification/enums/notification-type.enum';
 
+/**
+ * ## Deletion / lifecycle semantics
+ *
+ * `InsuranceService` never issues direct `prisma.delete()` or
+ * `prisma.update()` calls for record removal.  All mutations go through
+ * `InsurancePolicyRepository`, which extends `SoftDeleteRepository`.
+ *
+ * - **Cancellation / expiry** → `policyRepository.updateStatus()` sets the
+ *   `status` column.  The policy row remains live in the database (visible to
+ *   standard queries) so that historical reads and audit trails work correctly.
+ * - **Soft-delete** (when a policy must be hidden from standard queries) →
+ *   call `policyRepository.delete(id)`.  The soft-delete middleware converts
+ *   this to `UPDATE … SET deleted_at = NOW()`.
+ * - **Hard delete (purge)** → only via `SoftDeleteService.hardDelete()` for
+ *   explicitly approved paths (GDPR erasure, admin purge).  Never call
+ *   `policyRepository.delete()` with a `hardDelete` flag outside
+ *   `SoftDeleteService`.
+ *
+ * See SOFT_DELETE_GUIDE.md for the full lifecycle state machine.
+ */
 @Injectable()
 export class InsuranceService {
   private readonly logger = new Logger(InsuranceService.name);

--- a/src/prisma.soft-delete.middleware.ts
+++ b/src/prisma.soft-delete.middleware.ts
@@ -1,7 +1,16 @@
 import { Prisma } from '@prisma/client';
 
 /**
- * Models that support soft delete (have deletedAt field)
+ * Models that support soft delete (have deletedAt field).
+ *
+ * Rules:
+ *  1. Every model listed here MUST have a `deletedAt DateTime?` column and an
+ *     `@@index([deletedAt])` in prisma/schema.prisma.
+ *  2. No model should be added to this list without also adding the migration.
+ *  3. To *bypass* soft-delete for a new model (e.g. an immutable event ledger),
+ *     leave it absent from this list and document the reason in SOFT_DELETE_GUIDE.md.
+ *
+ * See also: SOFT_DELETE_GUIDE.md §2
  */
 export const SOFT_DELETE_MODELS = [
   'User',
@@ -29,12 +38,16 @@ export const SOFT_DELETE_MODELS = [
 export type SoftDeleteModel = (typeof SOFT_DELETE_MODELS)[number];
 
 /**
- * Configuration for soft delete behavior
+ * Configuration for soft delete behavior.
  */
 export interface SoftDeleteConfig {
   /**
-   * Whether to exclude soft-deleted records by default
-   * Can be overridden per query with includeDeleted flag
+   * Whether to exclude soft-deleted records by default.
+   * Can be overridden per-query with the `_includeDeleted` flag inside `where`
+   * or the `includeDeleted` top-level query argument.
+   *
+   * Should always be `true` in production.  Pass `false` only in unit tests
+   * that need to assert on raw DB state.
    */
   excludeDeleted?: boolean;
 }
@@ -42,29 +55,73 @@ export interface SoftDeleteConfig {
 type MiddlewareNext = (params: Prisma.MiddlewareParams) => Promise<unknown>;
 
 type SoftDeleteWhere = Record<string, unknown> & {
+  /**
+   * Non-standard Prisma flag consumed by this middleware.
+   * When `true` inside `where`, the `deletedAt IS NULL` filter is suppressed
+   * and the flag is removed before the query reaches the database.
+   *
+   * Prefer `SoftDeleteService.findIncludingDeleted()` over using this flag
+   * directly in application code.
+   */
   _includeDeleted?: boolean;
+  /**
+   * Non-standard Prisma flag consumed by this middleware.
+   * When `true` inside `where` on a delete/deleteMany, the middleware does NOT
+   * convert the operation to a soft-delete UPDATE — the real SQL DELETE is
+   * forwarded to the database.
+   *
+   * Only `SoftDeleteService.hardDelete()` / `hardDeleteMany()` should set this
+   * flag.  Any other caller must justify the bypass with a comment.
+   */
   _hardDelete?: boolean;
 };
 
 interface SoftDeleteMiddlewareArgs {
   where?: SoftDeleteWhere;
+  /** Top-level alternative to `where._includeDeleted`. */
   includeDeleted?: boolean;
+  /** Top-level alternative to `where._hardDelete`. */
   hardDelete?: boolean;
   data?: Record<string, unknown>;
 }
 
 /**
- * Query extension to include soft-deleted records
- * Usage: await prisma.user.findMany({ includeDeleted: true })
- */
-declare global {
-  namespace PrismaJson {}
-}
-
-/**
- * Create soft delete middleware for Prisma
- * This middleware automatically filters out soft-deleted records
- * and prevents hard deletes unless explicitly allowed
+ * Create the global soft-delete Prisma middleware.
+ *
+ * Register this **once** in `PrismaService.onModuleInit()`:
+ *
+ * ```typescript
+ * this.$use(createSoftDeleteMiddleware({ excludeDeleted: true }));
+ * ```
+ *
+ * ## What this middleware does
+ *
+ * ### Read actions (findUnique, findUniqueOrThrow, findFirst, findFirstOrThrow,
+ *                   findMany, count, aggregate, groupBy)
+ *   - Injects `deletedAt: null` into `where` unless the caller passes
+ *     `_includeDeleted: true` (in `where`) or `includeDeleted: true`
+ *     (top-level).
+ *   - Removes the non-standard flags before forwarding to the database.
+ *
+ * ### Write actions — soft delete (delete, deleteMany)
+ *   - Converts to `update` / `updateMany` that stamps `deletedAt = NOW()`.
+ *   - Only rows where `deletedAt IS NULL` are touched (idempotent).
+ *   - Opt-out: pass `hardDelete: true` (top-level) or `_hardDelete: true`
+ *     (inside `where`) to bypass the conversion and issue a real SQL DELETE.
+ *
+ * ### Write actions — update / updateMany
+ *   - Injects `deletedAt: null` into `where` so updates cannot accidentally
+ *     touch soft-deleted rows.
+ *   - Restore exception: when `data.deletedAt === null` the filter is skipped
+ *     so soft-deleted rows can be recovered.
+ *
+ * ### Upsert
+ *   - Injects `deletedAt: null` into the `create` branch (new rows start live).
+ *   - Injects `deletedAt: null` into the `update` branch (prevents accidental
+ *     re-stamping of deletedAt via an incomplete payload).
+ *   - Callers that set `deletedAt` explicitly in either branch take precedence.
+ *
+ * See SOFT_DELETE_GUIDE.md for the full lifecycle and query conventions.
  */
 export function createSoftDeleteMiddleware(
   config: SoftDeleteConfig = { excludeDeleted: true },
@@ -73,62 +130,87 @@ export function createSoftDeleteMiddleware(
     const { model, action } = params;
     const args = getMiddlewareArgs(params);
 
-    // Only apply to models that support soft delete
+    // Only apply to models that support soft delete.
     if (!SOFT_DELETE_MODELS.includes(model as SoftDeleteModel)) {
       return next(params);
     }
 
-    // Handle find operations - add where clause for soft delete
+    // ── Read actions ──────────────────────────────────────────────────────────
+    //
+    // Covers: findUnique, findUniqueOrThrow, findFirst, findFirstOrThrow,
+    //         findMany, count, aggregate, groupBy
+    //
+    // groupBy and aggregate use a top-level `where` just like findMany, so
+    // the same injection logic applies without any special-casing.
     if (
-      ['findUnique', 'findUniqueOrThrow', 'findFirst', 'findMany'].includes(
-        action,
-      )
+      [
+        'findUnique',
+        'findUniqueOrThrow',
+        'findFirst',
+        'findFirstOrThrow',
+        'findMany',
+        'count',
+        'aggregate',
+        'groupBy',
+      ].includes(action)
     ) {
-      // Check if includeDeleted is explicitly set to true in query options
       const includeDeleted = shouldIncludeDeleted(args);
 
       if (config.excludeDeleted && !includeDeleted) {
-        // Add deletedAt filter to where clause
         args.where = {
           ...args.where,
           deletedAt: null,
         };
       }
 
-      // Remove the flag from the query before sending to database
+      // Remove our non-standard flags before the query reaches the database.
       removeIncludeDeletedFlags(args);
+
+      return next(params);
     }
 
-    // Handle update operations - prevent updating through relations
+    // ── Update / UpdateMany ───────────────────────────────────────────────────
+    //
+    // Prevent updates from silently touching soft-deleted rows.
+    // Exception: restore operations set `data.deletedAt === null` and must
+    // be able to reach deleted rows — the filter is intentionally skipped
+    // for them.
     if (action === 'update' || action === 'updateMany') {
-      // Restore operations (data.deletedAt === null) must be able to reach
-      // soft-deleted rows, otherwise a deleted record could never be recovered.
+      // A restore is the only legitimate reason to update a deleted row.
+      // Detect it by checking for an explicit `null` (not undefined) on
+      // deletedAt in the data payload.
       const isRestore = args.data?.deletedAt === null;
 
-      // Only update non-deleted records
       if (config.excludeDeleted && !isRestore) {
         args.where = {
           ...args.where,
           deletedAt: null,
         };
       }
+
+      return next(params);
     }
 
-    // Handle delete operations - convert to soft delete
+    // ── Delete / DeleteMany ───────────────────────────────────────────────────
+    //
+    // Default: convert to a soft-delete UPDATE.
+    // Opt-out: `hardDelete: true` (top-level) or `where._hardDelete: true`
+    //          forwards the real SQL DELETE — used exclusively by
+    //          SoftDeleteService.hardDelete() / hardDeleteMany() and by
+    //          approved GDPR/admin paths.
     if (action === 'delete' || action === 'deleteMany') {
-      // Explicit, audited purge paths (e.g. SoftDeleteService.hardDelete,
-      // GDPR erasure, re-org rollbacks) may opt out of the conversion.
       if (shouldHardDelete(args)) {
+        // Strip the flag before forwarding so Prisma doesn't see it.
         removeHardDeleteFlags(args);
         return next(params);
       }
 
       removeHardDeleteFlags(args);
 
-      // Convert delete to update with deletedAt timestamp.
-      // Only touch rows that are not already soft-deleted so repeated
-      // deletes do not silently re-stamp deletedAt.
-      const updateArgs = {
+      // Convert delete → soft-delete UPDATE.
+      // Only rows that are NOT already soft-deleted are touched, making
+      // repeated calls idempotent.
+      const softDeleteArgs = {
         where: {
           ...args.where,
           deletedAt: null,
@@ -138,55 +220,22 @@ export function createSoftDeleteMiddleware(
         },
       };
 
-      // Execute update instead of delete
       return next({
         ...params,
         action: action === 'delete' ? 'update' : 'updateMany',
-        args: updateArgs,
+        args: softDeleteArgs,
       });
     }
 
-    // Handle count operations - exclude soft-deleted records
-    if (action === 'count') {
-      const includeDeleted = shouldIncludeDeleted(args);
-
-      if (config.excludeDeleted && !includeDeleted) {
-        args.where = {
-          ...args.where,
-          deletedAt: null,
-        };
-      }
-
-      removeIncludeDeletedFlags(args);
-    }
-
-    // Handle aggregate operations - exclude soft-deleted records
-    if (action === 'aggregate') {
-      const includeDeleted = shouldIncludeDeleted(args);
-
-      if (config.excludeDeleted && !includeDeleted) {
-        args.where = {
-          ...args.where,
-          deletedAt: null,
-        };
-      }
-
-      removeIncludeDeletedFlags(args);
-    }
-
-    // Handle upsert operations — prevent soft-deleted records from being
-    // accidentally resurrected and ensure newly-created rows via upsert
-    // are never stamped with a deleted timestamp.
+    // ── Upsert ────────────────────────────────────────────────────────────────
     //
-    // Strategy:
-    //  - Inject `deletedAt: null` into the `create` branch so new rows
-    //    start as non-deleted (guards against callers omitting the field).
-    //  - Inject `deletedAt: null` into the `update` branch so an upsert
-    //    that matches a live row cannot accidentally re-stamp deletedAt
-    //    as null via an incomplete payload.
+    // Guard new rows created via upsert so they always start as live
+    // (deletedAt: null), and prevent an incomplete `update` payload from
+    // accidentally clearing or setting deletedAt.
     //
-    // Opt-out: if the caller already includes `deletedAt` in their payload
-    // (e.g. an intentional restore or explicit set), we leave it untouched.
+    // Callers that explicitly provide `deletedAt` in their payload take
+    // precedence — the injected defaults are only applied when the field is
+    // absent.
     if (action === 'upsert') {
       const upsertArgs = args as unknown as {
         where?: Record<string, unknown>;
@@ -194,7 +243,7 @@ export function createSoftDeleteMiddleware(
         update?: Record<string, unknown>;
       };
 
-      // Ensure newly-created rows via upsert start as non-deleted.
+      // New rows created by the upsert must start as live.
       if (upsertArgs.create && !('deletedAt' in upsertArgs.create)) {
         upsertArgs.create = {
           ...upsertArgs.create,
@@ -202,18 +251,23 @@ export function createSoftDeleteMiddleware(
         };
       }
 
-      // Ensure the update branch does not inadvertently set deletedAt.
+      // Existing rows matched by the upsert must not have deletedAt touched
+      // unless the caller explicitly provides a value.
       if (upsertArgs.update && !('deletedAt' in upsertArgs.update)) {
         upsertArgs.update = {
           ...upsertArgs.update,
           deletedAt: null,
         };
       }
+
+      return next(params);
     }
 
     return next(params);
   };
 }
+
+// ── Private helpers ────────────────────────────────────────────────────────────
 
 function getMiddlewareArgs(
   params: Prisma.MiddlewareParams,
@@ -221,14 +275,25 @@ function getMiddlewareArgs(
   if (!params.args) {
     params.args = {};
   }
-
   return params.args as SoftDeleteMiddlewareArgs;
 }
 
+/**
+ * Returns true if the caller opted into seeing soft-deleted rows.
+ * Checks both the `where._includeDeleted` shorthand and the top-level
+ * `includeDeleted` flag for backwards compatibility.
+ */
 function shouldIncludeDeleted(args: SoftDeleteMiddlewareArgs): boolean {
   return args.where?._includeDeleted === true || args.includeDeleted === true;
 }
 
+/**
+ * Returns true if the caller explicitly requested a hard (permanent) delete.
+ * Checks both the `where._hardDelete` shorthand and the top-level `hardDelete`
+ * flag.
+ *
+ * Only `SoftDeleteService` and approved GDPR/admin paths should trigger this.
+ */
 function shouldHardDelete(args: SoftDeleteMiddlewareArgs): boolean {
   return args.where?._hardDelete === true || args.hardDelete === true;
 }

--- a/src/prisma.soft-delete.module.ts
+++ b/src/prisma.soft-delete.module.ts
@@ -3,11 +3,30 @@ import { DatabaseModule } from './database.module';
 import { SoftDeleteService } from './prisma.soft-delete.service';
 
 /**
- * Module for soft delete functionality
+ * Provides `SoftDeleteService` to feature modules that need:
+ *   - hard-delete (purge) operations
+ *   - restore operations
+ *   - admin / audit queries over soft-deleted records
+ *   - retention-based cleanup
  *
- * The soft delete middleware is automatically registered in PrismaService.onModuleInit()
+ * The soft-delete **middleware** is registered separately in
+ * `PrismaService.onModuleInit()` (inside `DatabaseModule`) and is always
+ * active for every Prisma query.  You do **not** need to import this module
+ * to benefit from transparent soft-delete filtering on standard queries.
  *
- * Import this module in your features that need soft delete utilities
+ * Import `SoftDeleteModule` only when your feature needs the advanced
+ * `SoftDeleteService` methods listed above.
+ *
+ * @example
+ * ```typescript
+ * @Module({
+ *   imports: [SoftDeleteModule],
+ *   providers: [MyAdminService],
+ * })
+ * export class MyAdminModule {}
+ * ```
+ *
+ * See also: SOFT_DELETE_GUIDE.md §6
  */
 @Module({
   imports: [DatabaseModule],

--- a/src/prisma.soft-delete.service.ts
+++ b/src/prisma.soft-delete.service.ts
@@ -5,9 +5,14 @@ import type { SoftDeleteModel } from './prisma.soft-delete.middleware';
 
 type SoftDeleteDelegateName = Uncapitalize<SoftDeleteModel>;
 
-/** Generic Prisma query options shape used by soft-delete helpers. */
+/**
+ * Generic Prisma query options shape used by soft-delete helpers.
+ * The `includeDeleted` field is consumed by this service and stripped
+ * before the query reaches the database.
+ */
 interface QueryOptions {
   where?: Record<string, unknown>;
+  /** @deprecated Pass `_includeDeleted: true` inside `where` instead. */
   includeDeleted?: boolean;
   [key: string]: unknown;
 }
@@ -35,12 +40,33 @@ interface SoftDeleteDelegate {
 }
 
 /**
- * Service providing utility methods for soft delete operations
- * Use this service when you need to:
- * - Permanently delete records (hard delete)
- * - Restore soft-deleted records
- * - Query both deleted and non-deleted records
- * - Force include deleted records in specific queries
+ * Service providing utility methods for soft-delete, restore, and purge
+ * operations across all soft-deletable models.
+ *
+ * ## When to use this service
+ *
+ * | Scenario | Method |
+ * |---|---|
+ * | Permanent (hard) delete of one record | `hardDelete()` |
+ * | Permanent (hard) delete of many records | `hardDeleteMany()` |
+ * | Restore a soft-deleted record | `restore()` / `restoreMany()` |
+ * | Query including deleted records | `findIncludingDeleted()` / `findManyIncludingDeleted()` |
+ * | Query only deleted records | `findManyDeleted()` |
+ * | Count deleted records | `countDeleted()` |
+ * | Retention-based cleanup | `permanentlyDeleteExpired()` |
+ * | Check if a record is deleted | `isDeleted()` |
+ *
+ * Normal application code (outside GDPR/admin/retention flows) should use
+ * repository methods (`SoftDeleteRepository`) and rely on the middleware to
+ * transparently soft-delete records.
+ *
+ * ## Audit trail
+ *
+ * Every hard-delete (purge) operation writes a best-effort `AuditLog` entry
+ * with `action: AuditAction.DELETE`.  A failed audit write is logged as an
+ * error but does NOT fail the purge — the purge has already committed.
+ *
+ * See also: SOFT_DELETE_GUIDE.md §6, §8, §9
  */
 @Injectable()
 export class SoftDeleteService {
@@ -48,14 +74,21 @@ export class SoftDeleteService {
 
   constructor(private readonly prisma: PrismaService) {}
 
+  // ── Purge (hard delete) ─────────────────────────────────────────────────────
+
   /**
-   * Permanently delete a record (hard delete)
-   * WARNING: This permanently removes data from the database
-   * Use only when absolutely necessary (e.g., GDPR right to be forgotten)
+   * Permanently delete a single record from the database (hard delete).
    *
-   * @param model - The model name
-   * @param where - Filter conditions
-   * @param reason - Audit reason for permanent deletion
+   * ⚠️ This is irreversible.  Use only for:
+   *   - GDPR right-to-erasure
+   *   - Approved admin / retention flows
+   *
+   * Always supply a `reason` — it is written to the `AuditLog` and is
+   * critical for incident response.
+   *
+   * Internally passes `hardDelete: true` to the soft-delete middleware so
+   * the operation is forwarded as a real SQL DELETE rather than being
+   * converted to a soft-delete UPDATE.
    */
   async hardDelete<T>(
     model: SoftDeleteDelegateName,
@@ -63,11 +96,11 @@ export class SoftDeleteService {
     reason?: string,
   ): Promise<T | null> {
     this.logger.warn(
-      `Hard deleting ${model as string} with where: ${JSON.stringify(where)}. Reason: ${reason || 'Not provided'}`,
+      `Hard deleting ${model as string} with where: ${JSON.stringify(where)}. Reason: ${reason ?? 'Not provided'}`,
     );
 
-    // hardDelete: true opts out of the middleware's delete -> soft-delete
-    // conversion; without it this purge would silently become a soft delete.
+    // `hardDelete: true` opts out of the middleware's delete → soft-delete
+    // conversion.  Without it this call would silently become a soft delete.
     const result = await this.getDelegate(model).delete<T>({
       where,
       hardDelete: true,
@@ -79,12 +112,9 @@ export class SoftDeleteService {
   }
 
   /**
-   * Permanently delete multiple records (hard delete)
-   * WARNING: This permanently removes data from the database
+   * Permanently delete multiple records from the database (hard delete).
    *
-   * @param model - The model name
-   * @param where - Filter conditions
-   * @param reason - Audit reason for permanent deletion
+   * ⚠️ This is irreversible.  Always supply a `reason`.
    */
   async hardDeleteMany(
     model: SoftDeleteDelegateName,
@@ -92,7 +122,7 @@ export class SoftDeleteService {
     reason?: string,
   ): Promise<{ count: number }> {
     this.logger.warn(
-      `Hard deleting ${model as string} records. Reason: ${reason || 'Not provided'}`,
+      `Hard deleting ${model as string} records with where: ${JSON.stringify(where)}. Reason: ${reason ?? 'Not provided'}`,
     );
 
     const result = await this.getDelegate(model).deleteMany({
@@ -105,37 +135,44 @@ export class SoftDeleteService {
     return result;
   }
 
+  // ── Restore ─────────────────────────────────────────────────────────────────
+
   /**
-   * Restore a soft-deleted record
+   * Restore a single soft-deleted record by clearing `deletedAt`.
    *
-   * @param model - The model name
-   * @param where - Filter conditions
-   * @returns The restored record
+   * The underlying `update` call sets `data.deletedAt = null`, which the
+   * middleware recognises as a restore and skips the `deletedAt IS NULL`
+   * filter on `where` — allowing the deleted row to be reached.
    */
   async restore<T>(
     model: SoftDeleteDelegateName,
     where: Record<string, unknown>,
   ): Promise<T> {
-    this.logger.log(`Restoring ${model as string} record`);
+    this.logger.log(
+      `Restoring ${model as string} record: ${JSON.stringify(where)}`,
+    );
 
     return this.getDelegate(model).update<T>({
       where,
+      // data.deletedAt === null signals the middleware that this is a
+      // restore, causing it to bypass the deletedAt: null filter on `where`.
       data: { deletedAt: null },
     });
   }
 
   /**
-   * Restore multiple soft-deleted records
+   * Restore multiple soft-deleted records by clearing `deletedAt`.
    *
-   * @param model - The model name
-   * @param where - Filter conditions
-   * @returns Count of restored records
+   * Uses `updateMany` which also triggers the middleware restore path when
+   * `data.deletedAt === null`.
    */
-  async restoreMany<T>(
+  async restoreMany(
     model: SoftDeleteDelegateName,
     where: Record<string, unknown>,
   ): Promise<{ count: number }> {
-    this.logger.log(`Restoring multiple ${model as string} records`);
+    this.logger.log(
+      `Restoring multiple ${model as string} records: ${JSON.stringify(where)}`,
+    );
 
     return this.getDelegate(model).updateMany({
       where,
@@ -143,49 +180,58 @@ export class SoftDeleteService {
     });
   }
 
+  // ── Queries including / targeting deleted records ──────────────────────────
+
   /**
-   * Get a record including soft-deleted ones
+   * Find a single record regardless of its `deletedAt` status.
    *
-   * @param model - The model name
-   * @param where - Filter conditions
-   * @returns The record or null
+   * Injects `_includeDeleted: true` into `where`, which the middleware
+   * recognises and strips before the query reaches the database.
    */
   async findIncludingDeleted<T>(
     model: SoftDeleteDelegateName,
     where: Record<string, unknown>,
   ): Promise<T | null> {
     return this.getDelegate(model).findUnique<T>({
-      where,
-      ...{ includeDeleted: true },
-    });
-  }
-
-  /**
-   * Get multiple records including soft-deleted ones
-   *
-   * @param model - The model name
-   * @param options - Query options
-   * @returns Array of records
-   */
-  async findManyIncludingDeleted<T>(
-    model: SoftDeleteDelegateName,
-    options: QueryOptions = {},
-  ): Promise<T[]> {
-    return this.getDelegate(model).findMany<T>({
-      ...options,
       where: {
-        ...options.where,
-        ...(options.includeDeleted && { _includeDeleted: true }),
+        ...where,
+        _includeDeleted: true,
       },
     });
   }
 
   /**
-   * Get only soft-deleted records
+   * Find multiple records regardless of their `deletedAt` status.
    *
-   * @param model - The model name
-   * @param options - Query options
-   * @returns Array of deleted records
+   * Always injects `_includeDeleted: true` into `where` so the middleware
+   * skips the default `deletedAt IS NULL` filter.  Any `includeDeleted`
+   * property on `options` is accepted for backwards compatibility but is
+   * redundant — this method always includes deleted records.
+   */
+  async findManyIncludingDeleted<T>(
+    model: SoftDeleteDelegateName,
+    options: QueryOptions = {},
+  ): Promise<T[]> {
+    // Always inject _includeDeleted regardless of whether options.includeDeleted
+    // was set.  This is the authoritative "include deleted" query path —
+    // callers should not need to think about the flag.
+    const { includeDeleted: _unused, ...restOptions } = options;
+    void _unused; // consumed; not forwarded to Prisma
+
+    return this.getDelegate(model).findMany<T>({
+      ...restOptions,
+      where: {
+        ...restOptions.where,
+        _includeDeleted: true,
+      },
+    });
+  }
+
+  /**
+   * Find records that have been soft-deleted (`deletedAt IS NOT NULL`).
+   *
+   * This is the primary method for admin/audit views that need to enumerate
+   * what has been deleted without including live records.
    */
   async findManyDeleted<T>(
     model: SoftDeleteDelegateName,
@@ -201,11 +247,9 @@ export class SoftDeleteService {
   }
 
   /**
-   * Count soft-deleted records
+   * Count soft-deleted records matching the given `where` clause.
    *
-   * @param model - The model name
-   * @param where - Filter conditions
-   * @returns Count of deleted records
+   * Useful for admin dashboards and retention reporting.
    */
   async countDeleted(
     model: SoftDeleteDelegateName,
@@ -219,20 +263,29 @@ export class SoftDeleteService {
     });
   }
 
+  // ── Retention cleanup ───────────────────────────────────────────────────────
+
   /**
-   * Permanently delete expired soft-deleted records (cleanup)
-   * Records older than the specified time are permanently deleted
+   * Permanently delete soft-deleted records older than `deletedBefore`.
    *
-   * @param model - The model name
-   * @param deletedBefore - Date before which to delete
-   * @returns Count of permanently deleted records
+   * This is the canonical retention-cleanup path.  It:
+   *   1. Issues a `deleteMany` with `hardDelete: true` (bypasses middleware
+   *      conversion so rows are truly removed from the database).
+   *   2. Writes a best-effort `AuditLog` entry with the cleanup reason.
+   *
+   * Schedule this via a NestJS `@Cron()` job or an admin endpoint protected
+   * by appropriate role guards.
+   *
+   * @param model         - The model to purge (e.g. `'refreshToken'`)
+   * @param deletedBefore - Only purge rows soft-deleted before this date
+   * @returns             - Number of rows permanently deleted
    */
   async permanentlyDeleteExpired(
     model: SoftDeleteDelegateName,
     deletedBefore: Date,
   ): Promise<number> {
     this.logger.log(
-      `Permanently deleting ${model as string} records deleted before ${deletedBefore.toISOString()}`,
+      `Permanently deleting ${model as string} records soft-deleted before ${deletedBefore.toISOString()}`,
     );
 
     const where = {
@@ -250,19 +303,20 @@ export class SoftDeleteService {
     await this.recordPurgeAudit(
       model,
       where,
-      `Retention cleanup of records soft-deleted before ${deletedBefore.toISOString()}`,
+      `Retention cleanup — soft-deleted before ${deletedBefore.toISOString()}`,
       result.count,
     );
 
     return result.count;
   }
 
+  // ── Utility ─────────────────────────────────────────────────────────────────
+
   /**
-   * Check if a record is soft-deleted
+   * Returns `true` if the record exists in the database and has been
+   * soft-deleted (`deletedAt IS NOT NULL`).
    *
-   * @param model - The model name
-   * @param where - Filter conditions
-   * @returns True if record exists and is deleted, false otherwise
+   * Returns `false` if the record does not exist or is still live.
    */
   async isDeleted(
     model: SoftDeleteDelegateName,
@@ -271,20 +325,27 @@ export class SoftDeleteService {
     const record = await this.getDelegate(model).findUnique<{
       deletedAt?: Date | null;
     }>({
-      where,
-      ...{ includeDeleted: true },
+      where: {
+        ...where,
+        _includeDeleted: true,
+      },
     });
 
     return record?.deletedAt !== null && record?.deletedAt !== undefined;
   }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
 
   private getDelegate(model: SoftDeleteDelegateName): SoftDeleteDelegate {
     return this.prisma[model] as unknown as SoftDeleteDelegate;
   }
 
   /**
-   * Record an audit trail entry for a permanent deletion.
-   * Best-effort: a failed audit write is logged but does not fail the purge.
+   * Write an `AuditLog` entry for a permanent (hard) deletion.
+   *
+   * Best-effort: a failure here is logged as an error but does NOT roll back
+   * or fail the purge.  The purge has already been committed by the time this
+   * runs.
    */
   private async recordPurgeAudit(
     model: SoftDeleteDelegateName,
@@ -301,7 +362,7 @@ export class SoftDeleteService {
           beforeState: JSON.parse(
             JSON.stringify({ where, ...(count !== undefined && { count }) }),
           ) as Prisma.InputJsonValue,
-          reason: reason || 'Hard delete (no reason provided)',
+          reason: reason ?? 'Hard delete (no reason provided)',
         },
       });
     } catch (error) {


### PR DESCRIPTION
- Add SOFT_DELETE_GUIDE.md as the authoritative soft-delete reference covering all 20 models, middleware action matrix, query conventions, repository layer, SoftDeleteService API, lifecycle state machine, audit/admin flows, hard-delete policy, and instructions for new models

- Fix middleware: add findFirstOrThrow and groupBy to read-actions block (both were unhandled, causing soft-deleted rows to leak through)

- Fix SoftDeleteService.findManyIncludingDeleted: always inject _includeDeleted: true regardless of options; strip the non-standard includeDeleted option before forwarding to Prisma

- Annotate BaseRepository.delete() clarifying it is a soft-delete via middleware, not a SQL DELETE

- Rewrite SoftDeleteRepository with class-level and per-method JSDoc explaining the middleware restore-detection contract

- Add class-level deletion-semantics JSDoc to InsuranceService and ClaimService; add inline comment on the intentional direct Prisma read in ClaimService.createClaim

- Add /// soft-delete doc-comment to all 20 deletedAt fields in schema

- Add soft-delete convention preamble block to prisma/schema.prisma closes #476 

- Add Soft-Delete Policy section + SOFT_DELETE_GUIDE.md link to README

- Annotate DatabaseModule and SoftDeleteModule with clear import guidance

Closes: soft-delete lifecycle documentation task